### PR TITLE
improve: journey event resolving during journey collection

### DIFF
--- a/common/src/main/java/tools/simrail/backend/common/journey/JourneyEventEntity.java
+++ b/common/src/main/java/tools/simrail/backend/common/journey/JourneyEventEntity.java
@@ -34,6 +34,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Index;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import java.time.OffsetDateTime;
 import java.util.Objects;
 import java.util.UUID;
@@ -42,6 +43,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.annotations.CreationTimestamp;
+import org.springframework.data.domain.Persistable;
 
 /**
  * A single event along the route of a journey.
@@ -63,7 +65,7 @@ import org.hibernate.annotations.CreationTimestamp;
   @Index(columnList = "journeyId, eventIndex, point_playable"),
   @Index(columnList = "journeyId, eventIndex, transport_category, transport_number, scheduledTime"),
 })
-public final class JourneyEventEntity {
+public final class JourneyEventEntity implements Persistable<UUID> {
 
   /**
    * The namespace used to generate UUIDv5 ids for event entities.
@@ -176,6 +178,12 @@ public final class JourneyEventEntity {
    */
   @Column
   private boolean additional;
+
+  /**
+   * Indicates if this journey event was newly created or already existed in the database.
+   */
+  @Transient
+  private boolean isNew;
 
   /**
    * Checks if one of the scheduled data fields differs from the given other entity.

--- a/info-collector/src/main/java/tools/simrail/backend/collector/journey/CollectorJourneyService.java
+++ b/info-collector/src/main/java/tools/simrail/backend/collector/journey/CollectorJourneyService.java
@@ -162,9 +162,7 @@ class CollectorJourneyService {
   }
 
   /**
-   * Resolves the journey events for the given server by using the given server id and journey ids, fetching and caching
-   * all missing journey events that are not cached but requested by the given id collection. Note that changes to the
-   * returned map are reflected into the cache and vice vera.
+   * Resolves the journey events that are associated with the given journey ids.
    *
    * @param journeyIds the ids of the journeys to get the events of.
    * @return the journey events for all requested journeys, in a journey id to events mapping.

--- a/info-collector/src/main/java/tools/simrail/backend/collector/journey/CollectorJourneyService.java
+++ b/info-collector/src/main/java/tools/simrail/backend/collector/journey/CollectorJourneyService.java
@@ -31,7 +31,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -51,12 +50,14 @@ import tools.simrail.backend.common.journey.JourneyEventRepository;
 @Service
 class CollectorJourneyService {
 
+  private static final Comparator<JourneyEventEntity> EVENT_BY_INDEX_COMPARATOR =
+    Comparator.comparingInt(JourneyEventEntity::getEventIndex);
+
   private final EntityManager entityManager;
   private final CollectorJourneyRepository journeyRepository;
   private final JourneyEventRepository journeyEventRepository;
 
   private final Map<UUID, Map<UUID, JourneyEntity>> activeJourneysByServer;
-  private final Map<UUID, Map<UUID, List<JourneyEventEntity>>> journeyEventsByServer;
 
   @Autowired
   public CollectorJourneyService(
@@ -68,7 +69,6 @@ class CollectorJourneyService {
     this.journeyRepository = journeyRepository;
     this.journeyEventRepository = journeyEventRepository;
     this.activeJourneysByServer = new ConcurrentHashMap<>();
-    this.journeyEventsByServer = new ConcurrentHashMap<>();
   }
 
   /**
@@ -166,36 +166,20 @@ class CollectorJourneyService {
    * all missing journey events that are not cached but requested by the given id collection. Note that changes to the
    * returned map are reflected into the cache and vice vera.
    *
-   * @param serverId   the id of the server to get the journey events of.
    * @param journeyIds the ids of the journeys to get the events of.
    * @return the journey events for all requested journeys, in a journey id to events mapping.
    */
   @Nonnull
-  public Map<UUID, List<JourneyEventEntity>> resolveCachedJourneyEvents(
-    @Nonnull UUID serverId,
-    @Nonnull Collection<UUID> journeyIds
-  ) {
-    Map<UUID, List<JourneyEventEntity>> cachedEvents = new HashMap<>(); // this.journeyEventsByServer.computeIfAbsent(serverId, _ -> new HashMap<>());
-
-    // check if there are journeys required that are not currently cached,
-    // resolve the events of these journeys from the database in that case
-    // and add them to the local cache of the server
-    var missingJourneyIds = new HashSet<>(journeyIds);
-    // missingJourneyIds.removeAll(cachedEvents.keySet());
-    if (!missingJourneyIds.isEmpty()) {
-      var eventsByJourneyId = this.journeyEventRepository.findAllByJourneyIdIn(missingJourneyIds)
-        .stream()
-        .collect(Collectors.groupingBy(JourneyEventEntity::getJourneyId, Collectors.collectingAndThen(
-          Collectors.toList(),
-          events -> {
-            events.sort(Comparator.comparingInt(JourneyEventEntity::getEventIndex));
-            return events;
-          }
-        )));
-      cachedEvents.putAll(eventsByJourneyId);
-    }
-
-    return cachedEvents;
+  public Map<UUID, List<JourneyEventEntity>> resolveJourneyEvents(@Nonnull Collection<UUID> journeyIds) {
+    return this.journeyEventRepository.findAllByJourneyIdIn(journeyIds)
+      .stream()
+      .collect(Collectors.groupingBy(JourneyEventEntity::getJourneyId, Collectors.collectingAndThen(
+        Collectors.toList(),
+        events -> {
+          events.sort(EVENT_BY_INDEX_COMPARATOR);
+          return events;
+        }
+      )));
   }
 
   /**
@@ -231,31 +215,15 @@ class CollectorJourneyService {
   }
 
   /**
-   * Updates all given journey events that were updated on the server with the given id in one batch while also updating
-   * the references of these events in the server event cache. If a journey is not already stored in the cached, the
-   * associated updated events will not be added to the cache.
+   * Persists all new journey events created during journey data collection on a server. Events that are not new will
+   * not be saved directly this is up to the persistence context to do once the current transaction closes.
    *
-   * @param serverId      the id of the server on which the journey events were updated.
-   * @param journeyEvents the updated journey events to persist and store in the cache.
+   * @param journeyEvents the updated journey events to persist.
    */
-  public void persistJourneyEventsAndPopulateCache(
-    @Nonnull UUID serverId,
-    @Nonnull Collection<JourneyEventEntity> journeyEvents
-  ) {
-    var savedEntities = this.journeyEventRepository.saveAll(journeyEvents);
-    var cachedJourneyEvents = this.journeyEventsByServer.get(serverId);
-    if (cachedJourneyEvents != null) {
-      for (var savedEntity : savedEntities) {
-        var events = cachedJourneyEvents.get(savedEntity.getJourneyId());
-        if (events != null) {
-          // this uses the fact that the equals method is only implemented using
-          // the id of the event which never changes. therefore, resolving the index
-          // of the old event entity is possible this way
-          var indexOfEvent = events.indexOf(savedEntity);
-          if (indexOfEvent != -1) {
-            events.set(indexOfEvent, savedEntity);
-          }
-        }
+  public void persistJourneyEvents(@Nonnull Collection<JourneyEventEntity> journeyEvents) {
+    for (JourneyEventEntity event : journeyEvents) {
+      if (event.isNew()) {
+        this.journeyEventRepository.save(event);
       }
     }
   }

--- a/info-collector/src/main/java/tools/simrail/backend/collector/journey/CollectorJourneyService.java
+++ b/info-collector/src/main/java/tools/simrail/backend/collector/journey/CollectorJourneyService.java
@@ -175,13 +175,13 @@ class CollectorJourneyService {
     @Nonnull UUID serverId,
     @Nonnull Collection<UUID> journeyIds
   ) {
-    var cachedEvents = this.journeyEventsByServer.computeIfAbsent(serverId, _ -> new HashMap<>());
+    Map<UUID, List<JourneyEventEntity>> cachedEvents = new HashMap<>(); // this.journeyEventsByServer.computeIfAbsent(serverId, _ -> new HashMap<>());
 
     // check if there are journeys required that are not currently cached,
     // resolve the events of these journeys from the database in that case
     // and add them to the local cache of the server
     var missingJourneyIds = new HashSet<>(journeyIds);
-    missingJourneyIds.removeAll(cachedEvents.keySet());
+    // missingJourneyIds.removeAll(cachedEvents.keySet());
     if (!missingJourneyIds.isEmpty()) {
       var eventsByJourneyId = this.journeyEventRepository.findAllByJourneyIdIn(missingJourneyIds)
         .stream()

--- a/info-collector/src/main/java/tools/simrail/backend/collector/journey/JourneyEventRealtimeUpdater.java
+++ b/info-collector/src/main/java/tools/simrail/backend/collector/journey/JourneyEventRealtimeUpdater.java
@@ -385,6 +385,7 @@ final class JourneyEventRealtimeUpdater {
   ) {
     var eventId = this.journeyEventIdFactory.create(journeyId.toString() + stop.getId() + previousEventId + type);
     var journeyEvent = new JourneyEventEntity();
+    journeyEvent.setNew(true);
     journeyEvent.setId(eventId);
     journeyEvent.setEventType(type);
     journeyEvent.setAdditional(true);

--- a/info-collector/src/main/java/tools/simrail/backend/collector/journey/SimRailServerTrainCollector.java
+++ b/info-collector/src/main/java/tools/simrail/backend/collector/journey/SimRailServerTrainCollector.java
@@ -169,7 +169,7 @@ class SimRailServerTrainCollector {
             .collect(Collectors.toMap(recorder -> recorder.getOriginal().getId(), Function.identity()));
           if (!relevantJourneys.isEmpty()) {
             var relevantJourneyIds = relevantJourneys.keySet();
-            var journeyEvents = this.journeyService.resolveCachedJourneyEvents(server.id(), relevantJourneyIds);
+            var journeyEvents = this.journeyService.resolveJourneyEvents(relevantJourneyIds);
             this.updateJourneyEvents(server, relevantJourneys.values(), journeyEvents);
           }
 
@@ -306,7 +306,7 @@ class SimRailServerTrainCollector {
         return updatedEvents.stream();
       })
       .toList();
-    this.journeyService.persistJourneyEventsAndPopulateCache(server.id(), updatedJourneys);
+    this.journeyService.persistJourneyEvents(updatedJourneys);
   }
 
   private @Nullable JourneySignalInfo constructNextSignal(@Nonnull SimRailPanelTrain.DetailData detailData) {


### PR DESCRIPTION
* remove local journey event cache, it's actually slower than pulling the events from the database directly
* remove explicit saving of updated event entities, leave that to the hibernate dirty checking when the transaction closes