### PR TITLE
chore: identify points by name

### DIFF
--- a/.data/border_points.json
+++ b/.data/border_points.json
@@ -1,258 +1,253 @@
 [
   {
     "name": "Katowice Muchowiec Staszic",
-    "ext_point_ids": [
-      "1637"
+    "point_names": [
+      "KATOWICE MUCHOWIEC STASZIC"
     ]
   },
   {
     "name": "Katowice Kostuchna",
-    "ext_point_ids": [
-      "1619"
+    "point_names": [
+      "Katowice Kostuchna"
     ]
   },
   {
     "name": "Brynów",
-    "ext_point_ids": [
-      "333"
+    "point_names": [
+      "Brynów"
     ]
   },
   {
     "name": "Katowice Tow. KTC",
-    "ext_point_ids": [
-      "1653"
-    ]
-  },
-  {
-    "name": "Szabelnia",
-    "ext_point_ids": [
-      "4236"
+    "point_names": [
+      "Katowice Tow. KTC"
     ]
   },
   {
     "name": "Sosnowiec Maczki",
-    "ext_point_ids": [
-      "4006"
+    "point_names": [
+      "Sosnowiec Maczki"
     ]
   },
   {
     "name": "Dąbrowa Górnicza Towarowa",
-    "ext_point_ids": [
-      "728",
-      "729"
+    "point_names": [
+      "Dąbrowa Górnicza Towarowa",
+      "Dąbrowa Górnicza Towarowa DTA"
     ]
   },
   {
     "name": "Myszków",
-    "ext_point_ids": [
-      "2777",
-      "2778"
+    "point_names": [
+      "Myszków",
+      "Myszków GT"
     ]
   },
   {
     "name": "Sędziszów",
-    "ext_point_ids": [
-      "3795",
-      "3797"
+    "point_names": [
+      "Sędziszów",
+      "Sędziszów Towarowy"
     ]
   },
   {
     "name": "Czarnca",
-    "ext_point_ids": [
-      "613",
-      "614",
-      "5461"
+    "point_names": [
+      "Czarnca",
+      "Czarnca "
     ]
   },
   {
     "name": "Koniecpol",
-    "ext_point_ids": [
-      "1828"
+    "point_names": [
+      "Koniecpol"
     ],
     "in_border_if_next": [
-      "4092"
+      "Starzyny"
     ]
   },
   {
     "name": "Żelisławice",
-    "ext_point_ids": [
-      "5392",
-      "5393"
+    "point_names": [
+      "Żelisławice"
     ]
   },
   {
     "name": "Radzice",
-    "ext_point_ids": [
-      "3519"
+    "point_names": [
+      "Radzice"
     ],
     "in_border_if_next": [
-      "1349",
-      "1350",
-      "1351"
+      "Idzikowice",
+      "Idzikowice Roz.12",
+      "Idzikowice Roz.18"
     ]
   },
   {
     "name": "Radzice PZS R31",
-    "ext_point_ids": [
-      "3520"
+    "point_names": [
+      "Radzice PZS R31"
     ],
     "in_border_if_next": [
-      "1349",
-      "1350",
-      "1351"
+      "Idzikowice",
+      "Idzikowice Roz.12",
+      "Idzikowice Roz.18"
     ]
   },
   {
     "name": "Warszawa Grochów",
-    "ext_point_ids": [
-      "4732",
-      "4734"
+    "point_names": [
+      "Warszawa Grochów",
+      "Warszawa Grochów R5"
     ]
   },
   {
     "name": "Warszawa Praga",
-    "ext_point_ids": [
-      "4762",
-      "4785",
-      "4787",
-      "4788"
+    "point_names": [
+      "Warszawa Praga PZS R15",
+      "Warszawa Praga WPT C",
+      "Warszawa Praga WPT M"
     ]
   },
   {
     "name": "Warszawa Gołąbki",
-    "ext_point_ids": [
-      "4727"
+    "point_names": [
+      "Warszawa Gołąbki"
     ]
   },
   {
     "name": "Warszawa Główna Towarowa",
-    "ext_point_ids": [
-      "4718",
-      "4719",
-      "4723"
+    "point_names": [
+      "Warszawa Główna Towarowa",
+      "Warszawa Główna Towarowa WOA",
+      "Warszawa Gł.Tow.Sr18",
+      "Warszawa Gł.Tow. WOA"
     ]
   },
   {
     "name": "Dłubnia",
-    "ext_point_ids": [
-      "783",
-      "784"
+    "point_names": [
+      "Dłubnia",
+      "Dłubnia R2"
     ]
   },
   {
     "name": "Kraków Płaszów",
-    "ext_point_ids": [
-      "1927",
-      "2003"
+    "point_names": [
+      "Kraków Płaszów",
+      "Kraków Płaszów R3-4",
+      "Kr.Płaszów pzs KPA"
     ],
     "in_border_if_next": [
-      "1952"
+      "Kraków Główny"
     ]
   },
   {
     "name": "Kraków Zabłocie",
-    "ext_point_ids": [
-      "2030"
+    "point_names": [
+      "Kraków Zabłocie"
     ]
   },
   {
     "name": "Kraków Olsza",
-    "ext_point_ids": [
-      "1998",
-      "1999"
+    "point_names": [
+      "Kraków Olsza",
+      "Kraków Olsza R2"
     ]
   },
   {
     "name": "Borowa Górka",
-    "ext_point_ids": [
-      "285"
+    "point_names": [
+      "Borowa Górka"
     ]
   },
   {
     "name": "Marków",
-    "ext_point_ids": [
-      "2547"
+    "point_names": [
+      "Marków"
     ],
     "in_border_if_next": [
-      "4338"
+      "Szeligi"
     ]
   },
   {
     "name": "Warszawa Podskarbińska",
-    "ext_point_ids": [
-      "4758"
+    "point_names": [
+      "Warszawa Podskarbińska"
     ]
   },
   {
     "name": "Bełchów",
-    "ext_point_ids": [
-      "113"
+    "point_names": [
+      "Bełchów"
     ]
   },
   {
     "name": "Chrusty Nowe",
-    "ext_point_ids": [
-      "521"
+    "point_names": [
+      "Chrusty Nowe"
     ]
   },
   {
     "name": "Mikołajów",
-    "ext_point_ids": [
-      "2628"
+    "point_names": [
+      "Mikołajów"
     ]
   },
   {
     "name": "Słotwiny",
-    "ext_point_ids": [
-      "3928"
+    "point_names": [
+      "Słotwiny",
+      "Słotwiny R1"
     ]
   },
   {
     "name": "Puszcza Mariańska",
-    "ext_point_ids": [
-      "3459"
+    "point_names": [
+      "Puszcza Mariańska"
     ]
   },
   {
     "name": "Rozprza",
-    "ext_point_ids": [
-      "3617"
+    "point_names": [
+      "Rozprza"
     ]
   },
   {
     "name": "Łódź Fabryczna",
-    "ext_point_ids": [
-      "2431"
+    "point_names": [
+      "Łódź Fabryczna"
     ]
   },
   {
     "name": "Glinnik",
-    "ext_point_ids": [
-      "1057"
+    "point_names": [
+      "Glinnik"
     ]
   },
   {
     "name": "Zgierz Północ",
-    "ext_point_ids": [
-      "5314"
+    "point_names": [
+      "Zgierz Północ"
     ]
   },
   {
     "name": "Zduńska Wola Karsznice",
-    "ext_point_ids": [
-      "5292"
+    "point_names": [
+      "Zduńska Wola Karsznice"
     ]
   },
   {
-    "name": "Dionizów R3",
-    "ext_point_ids": [
-      "780"
+    "name": "Dionizów",
+    "point_names": [
+      "Dionizów",
+      "Dionizów R3"
     ]
   },
   {
     "name": "Sędzice",
-    "ext_point_ids": [
-      "3792"
+    "point_names": [
+      "Sędzice"
     ]
   }
 ]

--- a/.data/points.json
+++ b/.data/points.json
@@ -5,8 +5,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "673"
+    "names": [
+      "Częstochowa"
     ],
     "bb": [
       [
@@ -44,9 +44,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "684",
-      "685"
+    "names": [
+      "Częstochowa Towarowa",
+      "Częstochowa Tow Ctb"
     ],
     "bb": [
       [
@@ -84,8 +84,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "680"
+    "names": [
+      "Częstochowa Raków"
     ],
     "bb": [
       [
@@ -123,10 +123,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3305",
-      "3306",
-      "5484"
+    "names": [
+      "Poraj GT",
+      "Poraj"
     ],
     "bb": [
       [
@@ -164,8 +163,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "5380"
+    "names": [
+      "Żarki-Letnisko"
     ],
     "bb": [
       [
@@ -203,9 +202,9 @@
     "prefix": "My",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2777",
-      "2778"
+    "names": [
+      "Myszków",
+      "Myszków GT"
     ],
     "bb": [
       [
@@ -243,9 +242,10 @@
     "prefix": "Zw",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5262",
-      "5264"
+    "names": [
+      "Zawiercie",
+      "Zawiercie GT",
+      "Zawiercie R97"
     ],
     "bb": [
       [
@@ -303,10 +303,10 @@
     "prefix": "LA",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2372",
-      "2374",
-      "2376"
+    "names": [
+      "Łazy R52",
+      "Łazy Ła",
+      "Łazy Grupa Węglarkowa ŁGW"
     ],
     "bb": [
       [
@@ -344,8 +344,9 @@
     "prefix": "LB",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2371"
+    "names": [
+      "Łazy",
+      "Łazy Ł11"
     ],
     "bb": [
       [
@@ -383,8 +384,8 @@
     "prefix": "Pmi",
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "3398"
+    "names": [
+      "Przemiarki"
     ],
     "bb": [
       [
@@ -422,8 +423,8 @@
     "prefix": "LC",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2375"
+    "names": [
+      "Łazy Łc"
     ],
     "bb": [
       [
@@ -461,11 +462,11 @@
     "prefix": "DZ",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "713",
-      "734",
-      "735",
-      "736"
+    "names": [
+      "Dąbrowa Górn. Ząbkowice DZA R.4/7",
+      "Dąbrowa Górnicza Ząbkowice GTB",
+      "Dąbrowa Górnicza Ząbkowice DZA",
+      "Dąbrowa Górnicza Ząbkowice"
     ],
     "bb": [
       [
@@ -503,8 +504,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "720"
+    "names": [
+      "Dąbrowa Górnicza Gołonóg"
     ],
     "bb": [
       [
@@ -542,8 +543,8 @@
     "prefix": "DG",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "719"
+    "names": [
+      "Dąbrowa Górnicza"
     ],
     "bb": [
       [
@@ -581,8 +582,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "125"
+    "names": [
+      "Będzin Ksawera"
     ],
     "bb": [
       [
@@ -620,8 +621,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "127"
+    "names": [
+      "Będzin Miasto"
     ],
     "bb": [
       [
@@ -659,8 +660,8 @@
     "prefix": "B",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "124"
+    "names": [
+      "Będzin"
     ],
     "bb": [
       [
@@ -698,8 +699,8 @@
     "prefix": "SG",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3993"
+    "names": [
+      "Sosnowiec Główny"
     ],
     "bb": [
       [
@@ -737,8 +738,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "1649"
+    "names": [
+      "Katowice Szopienice Południowe"
     ],
     "bb": [
       [
@@ -776,8 +777,8 @@
     "prefix": "KZ",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1655"
+    "names": [
+      "Katowice Zawodzie"
     ],
     "bb": [
       [
@@ -815,8 +816,8 @@
     "prefix": "KO",
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "1614"
+    "names": [
+      "Katowice"
     ],
     "bb": [
       [
@@ -854,8 +855,8 @@
     "prefix": "l139_bry",
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "1615"
+    "names": [
+      "Katowice Brynów"
     ],
     "bb": [
       [
@@ -893,8 +894,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "1624"
+    "names": [
+      "Katowice Ligota"
     ],
     "bb": [
       [
@@ -932,8 +933,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": true,
-    "ids": [
-      "1641"
+    "names": [
+      "Katowice Piotrowice"
     ],
     "bb": [
       [
@@ -971,8 +972,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": true,
-    "ids": [
-      "1642"
+    "names": [
+      "Katowice Podlesie"
     ],
     "bb": [
       [
@@ -1010,8 +1011,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4618"
+    "names": [
+      "Tychy"
     ],
     "bb": [
       [
@@ -1049,8 +1050,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4628"
+    "names": [
+      "Tychy Zachodnie"
     ],
     "bb": [
       [
@@ -1088,8 +1089,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4619"
+    "names": [
+      "Tychy Aleja Bielska"
     ],
     "bb": [
       [
@@ -1127,8 +1128,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4621"
+    "names": [
+      "Tychy Grota Roweckiego"
     ],
     "bb": [
       [
@@ -1166,8 +1167,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4623"
+    "names": [
+      "Tychy Miasto"
     ],
     "bb": [
       [
@@ -1205,8 +1206,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": true,
-    "ids": [
-      "4622"
+    "names": [
+      "Tychy Lodowisko"
     ],
     "bb": [
       [
@@ -1244,9 +1245,9 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4732",
-      "4734"
+    "names": [
+      "Warszawa Grochów",
+      "Warszawa Grochów R5"
     ],
     "bb": [
       [
@@ -1284,10 +1285,10 @@
     "prefix": "WSD",
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4817",
-      "4820",
-      "4824"
+    "names": [
+      "Warszawa Wschodnia",
+      "Warszawa Wsch.R.34",
+      "Warszawa Wsch. R.58"
     ],
     "bb": [
       [
@@ -1325,8 +1326,8 @@
     "prefix": "WDC",
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4700"
+    "names": [
+      "Warszawa Centralna"
     ],
     "bb": [
       [
@@ -1388,11 +1389,10 @@
     "prefix": "WZD",
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "4827",
-      "4829",
-      "4837",
-      "4839"
+    "names": [
+      "Warszawa Zachodnia",
+      "Warszawa Zach. R19",
+      "Warszawa Zach. R10"
     ],
     "bb": [
       [
@@ -1430,8 +1430,12 @@
     "prefix": "Wl",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4811"
+    "names": [
+      "Warszawa Włochy",
+      "Warszawa Włochy R21",
+      "Warszawa Włochy R22",
+      "Warszawa Włochy R51",
+      "Warszawa Włochy PZS R51"
     ],
     "bb": [
       [
@@ -1469,7 +1473,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [],
+    "names": [
+      "Warszawa Główna"
+    ],
     "bb": [
       [
         20.979379335,
@@ -1506,10 +1512,9 @@
     "prefix": "Pr",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "1539",
-      "1540",
-      "3384"
+    "names": [
+      "Pruszków",
+      "Józefinów"
     ],
     "bb": [
       [
@@ -1547,10 +1552,10 @@
     "prefix": "Gr",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "1250",
-      "1251",
-      "1252"
+    "names": [
+      "Grodzisk Mazowiecki",
+      "Grodzisk Mazowiecki R64",
+      "Grodzisk Maz. R58"
     ],
     "bb": [
       [
@@ -1588,8 +1593,8 @@
     "prefix": "Kr",
     "max_speed": 200,
     "stop_place": false,
-    "ids": [
-      "1852"
+    "names": [
+      "Korytów"
     ],
     "bb": [
       [
@@ -1627,8 +1632,8 @@
     "prefix": "Se",
     "max_speed": 200,
     "stop_place": false,
-    "ids": [
-      "4338"
+    "names": [
+      "Szeligi"
     ],
     "bb": [
       [
@@ -1666,8 +1671,8 @@
     "prefix": "BR",
     "max_speed": 200,
     "stop_place": false,
-    "ids": [
-      "139"
+    "names": [
+      "Biała Rawska"
     ],
     "bb": [
       [
@@ -1705,8 +1710,8 @@
     "prefix": "St",
     "max_speed": 200,
     "stop_place": false,
-    "ids": [
-      "4147"
+    "names": [
+      "Strzałki"
     ],
     "bb": [
       [
@@ -1744,10 +1749,10 @@
     "prefix": "Id",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "1349",
-      "1350",
-      "1351"
+    "names": [
+      "Idzikowice Roz.12",
+      "Idzikowice Roz.18",
+      "Idzikowice"
     ],
     "bb": [
       [
@@ -1785,8 +1790,8 @@
     "prefix": "Op",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2993"
+    "names": [
+      "Opoczno Południe"
     ],
     "bb": [
       [
@@ -1824,8 +1829,8 @@
     "prefix": "Pi",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "3200"
+    "names": [
+      "Pilichowice"
     ],
     "bb": [
       [
@@ -1863,8 +1868,8 @@
     "prefix": "Ol",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2969"
+    "names": [
+      "Olszamowice"
     ],
     "bb": [
       [
@@ -1902,8 +1907,8 @@
     "prefix": "WP",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "4987"
+    "names": [
+      "Włoszczowa Północ"
     ],
     "bb": [
       [
@@ -1941,9 +1946,9 @@
     "prefix": "Kn",
     "max_speed": 200,
     "stop_place": false,
-    "ids": [
-      "1772",
-      "1773"
+    "names": [
+      "Knapówka R2",
+      "Knapówka"
     ],
     "bb": [
       [
@@ -1981,9 +1986,9 @@
     "prefix": "Ps",
     "max_speed": 200,
     "stop_place": false,
-    "ids": [
-      "3436",
-      "3437"
+    "names": [
+      "Psary",
+      "Psary Roz.40"
     ],
     "bb": [
       [
@@ -2021,9 +2026,9 @@
     "prefix": "Str",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4092",
-      "4093"
+    "names": [
+      "Starzyny",
+      "Starzyny R5"
     ],
     "bb": [
       [
@@ -2061,8 +2066,8 @@
     "prefix": "Sp",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "4021"
+    "names": [
+      "Sprowa"
     ],
     "bb": [
       [
@@ -2100,8 +2105,8 @@
     "prefix": "Kz",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1917"
+    "names": [
+      "Kozłów"
     ],
     "bb": [
       [
@@ -2139,9 +2144,9 @@
     "prefix": "Tl",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "4595",
-      "4596"
+    "names": [
+      "Tunel",
+      "Tunel R13"
     ],
     "bb": [
       [
@@ -2179,8 +2184,8 @@
     "prefix": "Mi",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "2592"
+    "names": [
+      "Miechów"
     ],
     "bb": [
       [
@@ -2218,8 +2223,8 @@
     "prefix": "Sm",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "3923"
+    "names": [
+      "Słomniki"
     ],
     "bb": [
       [
@@ -2257,8 +2262,8 @@
     "prefix": "Nd",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "2820"
+    "names": [
+      "Niedźwiedź"
     ],
     "bb": [
       [
@@ -2296,8 +2301,8 @@
     "prefix": "Zs",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "5251"
+    "names": [
+      "Zastów"
     ],
     "bb": [
       [
@@ -2335,8 +2340,8 @@
     "prefix": "BT",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "1937"
+    "names": [
+      "Kraków Batowice"
     ],
     "bb": [
       [
@@ -2374,8 +2379,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1952"
+    "names": [
+      "Kraków Główny",
+      "Kraków Główny R110"
     ],
     "bb": [
       [
@@ -2413,8 +2419,8 @@
     "prefix": "GW",
     "max_speed": 200,
     "stop_place": false,
-    "ids": [
-      "1193"
+    "names": [
+      "Góra Włodowska"
     ],
     "bb": [
       [
@@ -2452,8 +2458,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "500"
+    "names": [
+      "Chorzów Batory"
     ],
     "bb": [
       [
@@ -2491,8 +2497,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3635"
+    "names": [
+      "Ruda Chebzie"
     ],
     "bb": [
       [
@@ -2530,8 +2536,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "5169"
+    "names": [
+      "Zabrze"
     ],
     "bb": [
       [
@@ -2569,8 +2575,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1060"
+    "names": [
+      "Gliwice"
     ],
     "bb": [
       [
@@ -2608,8 +2614,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "3638"
+    "names": [
+      "Ruda Kochłowice"
     ],
     "bb": [
       [
@@ -2647,8 +2653,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "3633"
+    "names": [
+      "Ruda Bielszowice"
     ],
     "bb": [
       [
@@ -2686,8 +2692,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "5176"
+    "names": [
+      "Zabrze Makoszowy"
     ],
     "bb": [
       [
@@ -2725,8 +2731,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "1774"
+    "names": [
+      "Knurów"
     ],
     "bb": [
       [
@@ -2764,8 +2770,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2207"
+    "names": [
+      "Leszczyny"
     ],
     "bb": [
       [
@@ -2803,8 +2809,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3685"
+    "names": [
+      "Rybnik"
     ],
     "bb": [
       [
@@ -2842,9 +2848,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3704",
-      "3705"
+    "names": [
+      "Rybnik Towarowy pzs RTB11",
+      "Rybnik Towarowy"
     ],
     "bb": [
       [
@@ -2882,8 +2888,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "5437"
+    "names": [
+      "Radlin Obszary"
     ],
     "bb": [
       [
@@ -2921,8 +2927,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4992"
+    "names": [
+      "Wodzisław Śląski"
     ],
     "bb": [
       [
@@ -2960,8 +2966,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2984"
+    "names": [
+      "Olza"
     ],
     "bb": [
       [
@@ -2999,8 +3005,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "439"
+    "names": [
+      "Chałupki"
     ],
     "bb": [
       [
@@ -3038,9 +3044,8 @@
     "prefix": "Zes",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5392",
-      "5393"
+    "names": [
+      "Żelisławice"
     ],
     "bb": [
       [
@@ -3078,8 +3083,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1828"
+    "names": [
+      "Koniecpol"
     ],
     "bb": [
       [
@@ -3117,8 +3122,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": true,
-    "ids": [
-      "3265"
+    "names": [
+      "Podlesie"
     ],
     "bb": [
       [
@@ -3156,8 +3161,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1544"
+    "names": [
+      "Julianka"
     ],
     "bb": [
       [
@@ -3195,8 +3200,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": true,
-    "ids": [
-      "2346"
+    "names": [
+      "Lusławice"
     ],
     "bb": [
       [
@@ -3234,8 +3239,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "4604"
+    "names": [
+      "Turów"
     ],
     "bb": [
       [
@@ -3273,8 +3278,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "682"
+    "names": [
+      "Częstochowa Stradom"
     ],
     "bb": [
       [
@@ -3312,8 +3317,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "675"
+    "names": [
+      "Częstochowa Gnaszyn"
     ],
     "bb": [
       [
@@ -3351,8 +3356,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": false,
-    "ids": [
-      "222"
+    "names": [
+      "Blachownia"
     ],
     "bb": [
       [
@@ -3390,8 +3395,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1316"
+    "names": [
+      "Herby Stare"
     ],
     "bb": [
       [
@@ -3429,8 +3434,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": false,
-    "ids": [
-      "2277"
+    "names": [
+      "Lisów"
     ],
     "bb": [
       [
@@ -3468,8 +3473,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": false,
-    "ids": [
-      "1791"
+    "names": [
+      "Kochanowice"
     ],
     "bb": [
       [
@@ -3507,8 +3512,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2331"
+    "names": [
+      "Lubliniec"
     ],
     "bb": [
       [
@@ -3546,8 +3551,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": false,
-    "ids": [
-      "3145"
+    "names": [
+      "Pawonków"
     ],
     "bb": [
       [
@@ -3585,8 +3590,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "3238"
+    "names": [
+      "Pludry"
     ],
     "bb": [
       [
@@ -3624,8 +3629,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "911"
+    "names": [
+      "Fosowskie"
     ],
     "bb": [
       [
@@ -3663,8 +3668,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "3088"
+    "names": [
+      "Ozimek"
     ],
     "bb": [
       [
@@ -3702,8 +3707,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "532"
+    "names": [
+      "Chrząstowice"
     ],
     "bb": [
       [
@@ -3741,8 +3746,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2998"
+    "names": [
+      "Opole Główne"
     ],
     "bb": [
       [
@@ -3780,8 +3785,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "3014"
+    "names": [
+      "Opole Zachodnie"
     ],
     "bb": [
       [
@@ -3819,8 +3824,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "741"
+    "names": [
+      "Dąbrowa Niemodlińska"
     ],
     "bb": [
       [
@@ -3858,8 +3863,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2220"
+    "names": [
+      "Lewin Brzeski"
     ],
     "bb": [
       [
@@ -3897,8 +3902,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "336"
+    "names": [
+      "Brzeg"
     ],
     "bb": [
       [
@@ -3936,8 +3941,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2987"
+    "names": [
+      "Oława"
     ],
     "bb": [
       [
@@ -3975,8 +3980,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "4418"
+    "names": [
+      "Święta Katarzyna"
     ],
     "bb": [
       [
@@ -4014,9 +4019,9 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "5060",
-      "5068"
+    "names": [
+      "Wrocław Główny",
+      "Wrocław Główny Wgb"
     ],
     "bb": [
       [
@@ -4054,8 +4059,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "1701"
+    "names": [
+      "Kielce"
     ],
     "bb": [
       [
@@ -4093,10 +4098,10 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1704",
-      "1705",
-      "1706"
+    "names": [
+      "Kielce Herbskie Khb",
+      "Kielce Herbskie Kha",
+      "Kielce Herbskie"
     ],
     "bb": [
       [
@@ -4129,13 +4134,14 @@
     }
   },
   {
-    "name": "Górki Szczukowskie",
+    "name": "Szczukowskie Górki",
     "id": "ee8c48dc-e681-400f-96dd-a24f5c37383e",
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1201"
+    "names": [
+      "Górki Szczukowskie",
+      "Szczukowskie Górki"
     ],
     "bb": [
       [
@@ -4173,8 +4179,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3722"
+    "names": [
+      "Rykoszyn"
     ],
     "bb": [
       [
@@ -4212,9 +4218,9 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "2528",
-      "5460"
+    "names": [
+      "Małogoszcz PZS R35",
+      "Małogoszcz"
     ],
     "bb": [
       [
@@ -4252,8 +4258,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "2344"
+    "names": [
+      "Ludynia"
     ],
     "bb": [
       [
@@ -4291,8 +4297,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "4986"
+    "names": [
+      "Włoszczowa"
     ],
     "bb": [
       [
@@ -4330,10 +4336,9 @@
     "prefix": "Cz",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "613",
-      "614",
-      "5461"
+    "names": [
+      "Czarnca",
+      "Czarnca "
     ],
     "bb": [
       [
@@ -4371,9 +4376,9 @@
     "prefix": "DGHK",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "721",
-      "722"
+    "names": [
+      "Dąbrowa Górnicza Huta Katowice R7",
+      "Dąbrowa Górnicza Huta Katowice"
     ],
     "bb": [
       [
@@ -4411,8 +4416,8 @@
     "prefix": "DP",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "725"
+    "names": [
+      "Dąbrowa Górnicza Południowa"
     ],
     "bb": [
       [
@@ -4450,8 +4455,8 @@
     "prefix": "Dra",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "835"
+    "names": [
+      "Dorota"
     ],
     "bb": [
       [
@@ -4489,8 +4494,8 @@
     "prefix": "Ju",
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "1545"
+    "names": [
+      "Juliusz"
     ],
     "bb": [
       [
@@ -4528,8 +4533,8 @@
     "prefix": "SDn",
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3990"
+    "names": [
+      "Sosnowiec Dańdówka"
     ],
     "bb": [
       [
@@ -4567,8 +4572,8 @@
     "prefix": "Spł1",
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4010"
+    "names": [
+      "Sosnowiec Południowy"
     ],
     "bb": [
       [
@@ -4606,8 +4611,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1702"
+    "names": [
+      "Kielce Białogon"
     ],
     "bb": [
       [
@@ -4645,8 +4650,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "1714"
+    "names": [
+      "Kielce Słowik"
     ],
     "bb": [
       [
@@ -4684,8 +4689,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3841"
+    "names": [
+      "Sitkówka Nowiny"
     ],
     "bb": [
       [
@@ -4723,8 +4728,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "5015"
+    "names": [
+      "Wolica"
     ],
     "bb": [
       [
@@ -4762,8 +4767,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3490"
+    "names": [
+      "Radkowice"
     ],
     "bb": [
       [
@@ -4801,8 +4806,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3954"
+    "names": [
+      "Sobków"
     ],
     "bb": [
       [
@@ -4840,8 +4845,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2588"
+    "names": [
+      "Miąsowa"
     ],
     "bb": [
       [
@@ -4879,8 +4884,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1533"
+    "names": [
+      "Jędrzejów"
     ],
     "bb": [
       [
@@ -4918,8 +4923,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "3314"
+    "names": [
+      "Potok"
     ],
     "bb": [
       [
@@ -4957,8 +4962,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "2079"
+    "names": [
+      "Krzcięcice"
     ],
     "bb": [
       [
@@ -4996,9 +5001,9 @@
     "prefix": "Sd",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3795",
-      "3797"
+    "names": [
+      "Sędziszów",
+      "Sędziszów Towarowy"
     ],
     "bb": [
       [
@@ -5036,8 +5041,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1744"
+    "names": [
+      "Klimontów"
     ],
     "bb": [
       [
@@ -5075,8 +5080,8 @@
     "prefix": "Ch",
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "447"
+    "names": [
+      "Charsznica"
     ],
     "bb": [
       [
@@ -5114,9 +5119,9 @@
     "prefix": "Ga",
     "max_speed": 50,
     "stop_place": true,
-    "ids": [
-      "922",
-      "5453"
+    "names": [
+      "Gajówka",
+      "Gajówka APO"
     ],
     "bb": [
       [
@@ -5154,8 +5159,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1532"
+    "names": [
+      "Jeżówka"
     ],
     "bb": [
       [
@@ -5193,8 +5198,8 @@
     "prefix": "W",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5013"
+    "names": [
+      "Wolbrom"
     ],
     "bb": [
       [
@@ -5232,9 +5237,9 @@
     "prefix": "Za",
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "5245",
-      "5454"
+    "names": [
+      "Zarzecze APO",
+      "Zarzecze"
     ],
     "bb": [
       [
@@ -5272,8 +5277,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "533"
+    "names": [
+      "Chrząstowice Olkuskie"
     ],
     "bb": [
       [
@@ -5311,8 +5316,8 @@
     "prefix": "JO",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1427"
+    "names": [
+      "Jaroszowiec Olkuski"
     ],
     "bb": [
       [
@@ -5350,8 +5355,8 @@
     "prefix": "O",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2966"
+    "names": [
+      "Olkusz"
     ],
     "bb": [
       [
@@ -5389,8 +5394,8 @@
     "prefix": "Bo",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "381"
+    "names": [
+      "Bukowno"
     ],
     "bb": [
       [
@@ -5428,8 +5433,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "382"
+    "names": [
+      "Bukowno Przymiarki"
     ],
     "bb": [
       [
@@ -5467,8 +5472,8 @@
     "prefix": "Sl",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3916"
+    "names": [
+      "Sławków"
     ],
     "bb": [
       [
@@ -5506,8 +5511,8 @@
     "prefix": "DW",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "733"
+    "names": [
+      "Dąbrowa Górnicza Wschodnia"
     ],
     "bb": [
       [
@@ -5545,9 +5550,9 @@
     "prefix": "DS",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "715",
-      "727"
+    "names": [
+      "Dąbr.Gór.Strzem. R75",
+      "Dąbrowa Górnicza Strzemieszyce"
     ],
     "bb": [
       [
@@ -5585,10 +5590,10 @@
     "prefix": "SKz",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "4003",
-      "4004",
-      "4005"
+    "names": [
+      "Sosnowiec Kazimierz",
+      "Sosnowiec Kazimierz PZS SKZ1",
+      "Sosnowiec Kazimierz PZS SKZ2"
     ],
     "bb": [
       [
@@ -5626,8 +5631,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "4012"
+    "names": [
+      "Sosnowiec Porąbka"
     ],
     "bb": [
       [
@@ -5665,8 +5670,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "3642"
+    "names": [
+      "Ruda Śląska"
     ],
     "bb": [
       [
@@ -5704,8 +5709,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "4421"
+    "names": [
+      "Świętochłowice"
     ],
     "bb": [
       [
@@ -5743,8 +5748,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "1654"
+    "names": [
+      "Katowice Załęże"
     ],
     "bb": [
       [
@@ -5782,8 +5787,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1851"
+    "names": [
+      "Korwinów"
     ],
     "bb": [
       [
@@ -5821,8 +5826,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2553"
+    "names": [
+      "Masłońskie Natalin"
     ],
     "bb": [
       [
@@ -5860,8 +5865,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2780"
+    "names": [
+      "Myszków Nowa Wieś"
     ],
     "bb": [
       [
@@ -5899,8 +5904,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2781"
+    "names": [
+      "Myszków Światowit"
     ],
     "bb": [
       [
@@ -5938,8 +5943,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2779"
+    "names": [
+      "Myszków Mrzygłód"
     ],
     "bb": [
       [
@@ -5977,8 +5982,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "5263"
+    "names": [
+      "Zawiercie Borowe Pole"
     ],
     "bb": [
       [
@@ -6016,8 +6021,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "4931"
+    "names": [
+      "Wiesiółka"
     ],
     "bb": [
       [
@@ -6055,8 +6060,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "522"
+    "names": [
+      "Chruszczobród"
     ],
     "bb": [
       [
@@ -6094,8 +6099,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "726"
+    "names": [
+      "Dąbrowa Górnicza Sikorka"
     ],
     "bb": [
       [
@@ -6133,8 +6138,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "724"
+    "names": [
+      "Dąbrowa Górnicza Pogoria"
     ],
     "bb": [
       [
@@ -6172,9 +6177,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "261",
-      "260"
+    "names": [
+      "Bohumín"
     ],
     "bb": [
       [
@@ -6212,8 +6216,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "1865"
+    "names": [
+      "Kostomłoty"
     ],
     "bb": [
       [
@@ -6251,8 +6255,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "5192"
+    "names": [
+      "Zagnańsk"
     ],
     "bb": [
       [
@@ -6290,8 +6294,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "2378"
+    "names": [
+      "Łączna"
     ],
     "bb": [
       [
@@ -6329,8 +6333,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "4191"
+    "names": [
+      "Suchedniów"
     ],
     "bb": [
       [
@@ -6368,8 +6372,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "4192"
+    "names": [
+      "Suchedniów Północny"
     ],
     "bb": [
       [
@@ -6407,8 +6411,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3863"
+    "names": [
+      "Skarżysko-Kamienna"
     ],
     "bb": [
       [
@@ -6446,8 +6450,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "349"
+    "names": [
+      "Brzeziny"
     ],
     "bb": [
       [
@@ -6485,8 +6489,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2811"
+    "names": [
+      "Nida"
     ],
     "bb": [
       [
@@ -6524,8 +6528,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4989"
+    "names": [
+      "Włoszczowice"
     ],
     "bb": [
       [
@@ -6563,8 +6567,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "5475"
+    "names": [
+      "Kije"
     ],
     "bb": [
       [
@@ -6602,8 +6606,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "390"
+    "names": [
+      "Busko-Zdrój"
     ],
     "bb": [
       [
@@ -6641,8 +6645,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "4802"
+    "names": [
+      "Warszawa Ursus"
     ],
     "bb": [
       [
@@ -6680,8 +6684,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "4803"
+    "names": [
+      "Warszawa Ursus Niedźwiadek"
     ],
     "bb": [
       [
@@ -6719,8 +6723,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3170"
+    "names": [
+      "Piastów"
     ],
     "bb": [
       [
@@ -6758,8 +6762,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3128"
+    "names": [
+      "Parzniew"
     ],
     "bb": [
       [
@@ -6797,8 +6801,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "332"
+    "names": [
+      "Brwinów"
     ],
     "bb": [
       [
@@ -6836,8 +6840,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2638"
+    "names": [
+      "Milanówek"
     ],
     "bb": [
       [
@@ -6875,8 +6879,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "1396"
+    "names": [
+      "Jaktorów"
     ],
     "bb": [
       [
@@ -6914,8 +6918,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "2614"
+    "names": [
+      "Międzyborów"
     ],
     "bb": [
       [
@@ -6953,8 +6957,8 @@
     "prefix": "5431_Zy",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "5431"
+    "names": [
+      "Żyrardów"
     ],
     "bb": [
       [
@@ -6992,8 +6996,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "4189"
+    "names": [
+      "Sucha Żyrardowska"
     ],
     "bb": [
       [
@@ -7031,8 +7035,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "1523"
+    "names": [
+      "Jesionka"
     ],
     "bb": [
       [
@@ -7070,9 +7074,8 @@
     "prefix": "3531_RM",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "3531",
-      "5516"
+    "names": [
+      "Radziwiłłów Mazowiecki"
     ],
     "bb": [
       [
@@ -7110,8 +7113,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "3891"
+    "names": [
+      "Skierniewice Rawka"
     ],
     "bb": [
       [
@@ -7149,12 +7152,14 @@
     "prefix": "3877_Sk",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "3877",
-      "3878",
-      "3880",
-      "3881",
-      "3892"
+    "names": [
+      "Skierniewice",
+      "Skierniewice R402",
+      "Skierniewice P PZS",
+      "Skierniewice S PZS",
+      "Skierniewice M PZS",
+      "Skierniewice GT L558",
+      "Skierniewice GT 201-208"
     ],
     "bb": [
       [
@@ -7192,8 +7197,8 @@
     "prefix": "StA",
     "max_speed": 30,
     "stop_place": false,
-    "ids": [
-      "1637"
+    "names": [
+      "KATOWICE MUCHOWIEC STASZIC"
     ],
     "bb": [
       [
@@ -7231,8 +7236,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3500"
+    "names": [
+      "Radom"
     ],
     "bb": [
       [
@@ -7270,8 +7275,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "3502"
+    "names": [
+      "Radom Południowy"
     ],
     "bb": [
       [
@@ -7309,8 +7314,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3620"
+    "names": [
+      "Rożki"
     ],
     "bb": [
       [
@@ -7348,8 +7353,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "3645"
+    "names": [
+      "Ruda Wielka"
     ],
     "bb": [
       [
@@ -7387,8 +7392,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "5005"
+    "names": [
+      "Wola Lipieniecka"
     ],
     "bb": [
       [
@@ -7426,8 +7431,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1454"
+    "names": [
+      "Jastrząb"
     ],
     "bb": [
       [
@@ -7465,8 +7470,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "945"
+    "names": [
+      "Gąsawy Plebańskie"
     ],
     "bb": [
       [
@@ -7504,8 +7509,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "4365"
+    "names": [
+      "Szydłowiec"
     ],
     "bb": [
       [
@@ -7543,8 +7548,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "2266"
+    "names": [
+      "Lipowe Pole"
     ],
     "bb": [
       [
@@ -7582,9 +7587,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3857",
-      "3864"
+    "names": [
+      "Skarżysko-Kam. Ska",
+      "Skarżysko-Kamienna PZS R154"
     ],
     "bb": [
       [
@@ -7622,8 +7627,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "3855"
+    "names": [
+      "Skarżysko Zachodnie"
     ],
     "bb": [
       [
@@ -7661,8 +7666,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "118"
+    "names": [
+      "Berezów"
     ],
     "bb": [
       [
@@ -7700,8 +7705,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "4594"
+    "names": [
+      "Tumlin"
     ],
     "bb": [
       [
@@ -7739,8 +7744,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "1712"
+    "names": [
+      "Kielce Piaski"
     ],
     "bb": [
       [
@@ -7778,8 +7783,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1619"
+    "names": [
+      "Katowice Kostuchna"
     ],
     "bb": [
       [
@@ -7817,10 +7822,10 @@
     "prefix": "2457_LW",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2457",
-      "2458",
-      "2462"
+    "names": [
+      "Łódź Widzew PZS R3",
+      "Łódź Widzew",
+      "Łódź Widzew R9"
     ],
     "bb": [
       [
@@ -7858,8 +7863,8 @@
     "prefix": null,
     "max_speed": 150,
     "stop_place": false,
-    "ids": [
-      "2422"
+    "names": [
+      "Łódź Andrzejów"
     ],
     "bb": [
       [
@@ -7897,8 +7902,8 @@
     "prefix": null,
     "max_speed": 150,
     "stop_place": true,
-    "ids": [
-      "110"
+    "names": [
+      "Bedoń"
     ],
     "bb": [
       [
@@ -7936,8 +7941,8 @@
     "prefix": null,
     "max_speed": 150,
     "stop_place": true,
-    "ids": [
-      "1548"
+    "names": [
+      "Justynów"
     ],
     "bb": [
       [
@@ -7975,8 +7980,8 @@
     "prefix": "924_G",
     "max_speed": 150,
     "stop_place": false,
-    "ids": [
-      "924"
+    "names": [
+      "Gałkówek"
     ],
     "bb": [
       [
@@ -8014,8 +8019,8 @@
     "prefix": null,
     "max_speed": 150,
     "stop_place": true,
-    "ids": [
-      "5375"
+    "names": [
+      "Żakowice"
     ],
     "bb": [
       [
@@ -8053,13 +8058,13 @@
     "prefix": "1803_KO",
     "max_speed": 150,
     "stop_place": false,
-    "ids": [
-      "1803",
-      "1806",
-      "1807",
-      "1808",
-      "1809",
-      "1811"
+    "names": [
+      "Koluszki PZS R154",
+      "Koluszki PZS R145",
+      "Koluszki",
+      "Koluszki R59",
+      "Koluszki R122",
+      "Koluszki R121"
     ],
     "bb": [
       [
@@ -8105,8 +8110,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "4857"
+    "names": [
+      "Wągry"
     ],
     "bb": [
       [
@@ -8144,8 +8149,8 @@
     "prefix": "3590_Rg",
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "3590"
+    "names": [
+      "Rogów"
     ],
     "bb": [
       [
@@ -8183,8 +8188,8 @@
     "prefix": null,
     "max_speed": 150,
     "stop_place": true,
-    "ids": [
-      "3423"
+    "names": [
+      "Przyłęk Duży"
     ],
     "bb": [
       [
@@ -8222,8 +8227,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "2059"
+    "names": [
+      "Krosnowa"
     ],
     "bb": [
       [
@@ -8261,8 +8266,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": true,
-    "ids": [
-      "2251"
+    "names": [
+      "Lipce Reymontowskie"
     ],
     "bb": [
       [
@@ -8300,9 +8305,9 @@
     "prefix": "3251_Pl",
     "max_speed": 150,
     "stop_place": false,
-    "ids": [
-      "3251",
-      "3252"
+    "names": [
+      "Płyćwia",
+      "Płyćwia GT"
     ],
     "bb": [
       [
@@ -8340,8 +8345,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": true,
-    "ids": [
-      "2501"
+    "names": [
+      "Maków"
     ],
     "bb": [
       [
@@ -8379,8 +8384,8 @@
     "prefix": null,
     "max_speed": 150,
     "stop_place": true,
-    "ids": [
-      "747"
+    "names": [
+      "Dąbrowice Skierniewickie"
     ],
     "bb": [
       [
@@ -8418,8 +8423,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "1793"
+    "names": [
+      "Kochcice"
     ],
     "bb": [
       [
@@ -8457,8 +8462,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "547"
+    "names": [
+      "Ciasna"
     ],
     "bb": [
       [
@@ -8496,8 +8501,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3832"
+    "names": [
+      "Sieraków Śląski"
     ],
     "bb": [
       [
@@ -8535,8 +8540,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4015"
+    "names": [
+      "Sowczyce"
     ],
     "bb": [
       [
@@ -8574,8 +8579,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2961"
+    "names": [
+      "Olesno Śląskie"
     ],
     "bb": [
       [
@@ -8613,8 +8618,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4065"
+    "names": [
+      "Stare Olesno"
     ],
     "bb": [
       [
@@ -8652,8 +8657,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "107"
+    "names": [
+      "Bąków"
     ],
     "bb": [
       [
@@ -8691,8 +8696,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1746"
+    "names": [
+      "Kluczbork"
     ],
     "bb": [
       [
@@ -8730,8 +8735,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "3938"
+    "names": [
+      "Smardy"
     ],
     "bb": [
       [
@@ -8769,8 +8774,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "5019"
+    "names": [
+      "Wołczyn"
     ],
     "bb": [
       [
@@ -8808,8 +8813,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4920"
+    "names": [
+      "Wierzbica Górna"
     ],
     "bb": [
       [
@@ -8847,8 +8852,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "829"
+    "names": [
+      "Domaszowice"
     ],
     "bb": [
       [
@@ -8886,8 +8891,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "1240"
+    "names": [
+      "Gręboszów"
     ],
     "bb": [
       [
@@ -8925,8 +8930,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "2792"
+    "names": [
+      "Namysłów"
     ],
     "bb": [
       [
@@ -8964,8 +8969,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4951"
+    "names": [
+      "Wilków Namysłowski"
     ],
     "bb": [
       [
@@ -9003,8 +9008,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "206"
+    "names": [
+      "Bierutów"
     ],
     "bb": [
       [
@@ -9042,8 +9047,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": true,
-    "ids": [
-      "3979"
+    "names": [
+      "Solniki Wielkie"
     ],
     "bb": [
       [
@@ -9081,8 +9086,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2963"
+    "names": [
+      "Oleśnica"
     ],
     "bb": [
       [
@@ -9120,8 +9125,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "288"
+    "names": [
+      "Borowa Oleśnicka"
     ],
     "bb": [
       [
@@ -9159,8 +9164,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "788"
+    "names": [
+      "Długołęka"
     ],
     "bb": [
       [
@@ -9198,8 +9203,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "5105"
+    "names": [
+      "Wrocław Psie Pole"
     ],
     "bb": [
       [
@@ -9237,8 +9242,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "5109"
+    "names": [
+      "Wrocław Sołtysowice"
     ],
     "bb": [
       [
@@ -9276,8 +9281,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "5081"
+    "names": [
+      "Wrocław Nadodrze"
     ],
     "bb": [
       [
@@ -9315,8 +9320,8 @@
     "prefix": null,
     "max_speed": 15,
     "stop_place": false,
-    "ids": [
-      "4620"
+    "names": [
+      "Tychy Fiat"
     ],
     "bb": [
       [
@@ -9354,8 +9359,8 @@
     "prefix": null,
     "max_speed": 75,
     "stop_place": false,
-    "ids": [
-      "1760"
+    "names": [
+      "Kłodzko Główne"
     ],
     "bb": [
       [
@@ -9393,8 +9398,8 @@
     "prefix": null,
     "max_speed": 75,
     "stop_place": true,
-    "ids": [
-      "2363"
+    "names": [
+      "Ławica"
     ],
     "bb": [
       [
@@ -9432,8 +9437,8 @@
     "prefix": null,
     "max_speed": 75,
     "stop_place": true,
-    "ids": [
-      "80"
+    "names": [
+      "Bardo Śląskie"
     ],
     "bb": [
       [
@@ -9471,8 +9476,8 @@
     "prefix": null,
     "max_speed": 75,
     "stop_place": false,
-    "ids": [
-      "79"
+    "names": [
+      "Bardo Przyłęk"
     ],
     "bb": [
       [
@@ -9510,8 +9515,8 @@
     "prefix": null,
     "max_speed": 75,
     "stop_place": true,
-    "ids": [
-      "4222"
+    "names": [
+      "Suszka"
     ],
     "bb": [
       [
@@ -9549,8 +9554,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "1579"
+    "names": [
+      "Kamieniec Ząbkowicki"
     ],
     "bb": [
       [
@@ -9588,8 +9593,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3096"
+    "names": [
+      "Paczków"
     ],
     "bb": [
       [
@@ -9627,8 +9632,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "3082"
+    "names": [
+      "Otmuchów Jezioro"
     ],
     "bb": [
       [
@@ -9666,8 +9671,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "3081"
+    "names": [
+      "Otmuchów"
     ],
     "bb": [
       [
@@ -9705,8 +9710,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "5030"
+    "names": [
+      "Wójcice"
     ],
     "bb": [
       [
@@ -9744,8 +9749,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "1181"
+    "names": [
+      "Goświnowice"
     ],
     "bb": [
       [
@@ -9783,8 +9788,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2917"
+    "names": [
+      "Nysa"
     ],
     "bb": [
       [
@@ -9822,8 +9827,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "2910"
+    "names": [
+      "Nowy Świętów"
     ],
     "bb": [
       [
@@ -9861,8 +9866,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": true,
-    "ids": [
-      "2898"
+    "names": [
+      "Nowy Las"
     ],
     "bb": [
       [
@@ -9900,8 +9905,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "4364"
+    "names": [
+      "Szybowice"
     ],
     "bb": [
       [
@@ -9939,8 +9944,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3373"
+    "names": [
+      "Prudnik"
     ],
     "bb": [
       [
@@ -9978,8 +9983,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "870"
+    "names": [
+      "Dytmarów"
     ],
     "bb": [
       [
@@ -10017,8 +10022,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3486"
+    "names": [
+      "Racławice Śląskie"
     ],
     "bb": [
       [
@@ -10056,8 +10061,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1089"
+    "names": [
+      "Głogówek"
     ],
     "bb": [
       [
@@ -10095,8 +10100,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4613"
+    "names": [
+      "Twardawa"
     ],
     "bb": [
       [
@@ -10134,8 +10139,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "3283"
+    "names": [
+      "Pokrzywnica"
     ],
     "bb": [
       [
@@ -10173,8 +10178,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1683"
+    "names": [
+      "Kędzierzyn-Koźle Zachodnie"
     ],
     "bb": [
       [
@@ -10212,8 +10217,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "1676"
+    "names": [
+      "Kędzierzyn-Koźle Przystanek"
     ],
     "bb": [
       [
@@ -10251,10 +10256,10 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "1672",
-      "1673",
-      "1667"
+    "names": [
+      "Kędzierzyn-Koźle",
+      "Kędzierzyn-Koźle Kkc",
+      "Kędzierzyn-Koźle Kkd"
     ],
     "bb": [
       [
@@ -10292,8 +10297,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3914"
+    "names": [
+      "Sławięcice"
     ],
     "bb": [
       [
@@ -10331,8 +10336,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "3663"
+    "names": [
+      "Rudziniec Gliwicki"
     ],
     "bb": [
       [
@@ -10370,8 +10375,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4433"
+    "names": [
+      "Taciszów"
     ],
     "bb": [
       [
@@ -10409,8 +10414,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "3738"
+    "names": [
+      "Rzeczyce Śląskie"
     ],
     "bb": [
       [
@@ -10448,8 +10453,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1064"
+    "names": [
+      "Gliwice Łabędy"
     ],
     "bb": [
       [
@@ -10487,8 +10492,8 @@
     "prefix": "SMA",
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4006"
+    "names": [
+      "Sosnowiec Maczki"
     ],
     "bb": [
       [
@@ -10526,8 +10531,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "872"
+    "names": [
+      "Dziadówki"
     ],
     "bb": [
       [
@@ -10565,8 +10570,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "1592"
+    "names": [
+      "Kamieńczyce"
     ],
     "bb": [
       [
@@ -10604,8 +10609,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "4320"
+    "names": [
+      "Szczepanowice"
     ],
     "bb": [
       [
@@ -10643,8 +10648,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "3951"
+    "names": [
+      "Smroków"
     ],
     "bb": [
       [
@@ -10682,8 +10687,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "3924"
+    "names": [
+      "Słomniki Miasto"
     ],
     "bb": [
       [
@@ -10721,8 +10726,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "1173"
+    "names": [
+      "Goszcza"
     ],
     "bb": [
       [
@@ -10760,8 +10765,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "2468"
+    "names": [
+      "Łuczyce"
     ],
     "bb": [
       [
@@ -10799,8 +10804,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "71"
+    "names": [
+      "Baranówka"
     ],
     "bb": [
       [
@@ -10838,10 +10843,10 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": true,
-    "ids": [
-      "1983",
-      "1984",
-      "1990"
+    "names": [
+      "Kraków Nowa Huta NHEO",
+      "Kraków Nowa Huta Nha",
+      "Kraków Nowa Huta NHA GTTR"
     ],
     "bb": [
       [
@@ -10879,8 +10884,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1472"
+    "names": [
+      "Jaworzno Szczakowa"
     ],
     "bb": [
       [
@@ -10918,9 +10923,9 @@
     "prefix": "Rd",
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "3519",
-      "3520"
+    "names": [
+      "Radzice PZS R31",
+      "Radzice"
     ],
     "bb": [
       [
@@ -10958,8 +10963,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "760"
+    "names": [
+      "Dęba Opoczyńska"
     ],
     "bb": [
       [
@@ -10997,8 +11002,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "42"
+    "names": [
+      "Antoniów"
     ],
     "bb": [
       [
@@ -11036,8 +11041,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "4527"
+    "names": [
+      "Tomaszów Mazowiecki Białobrzegi"
     ],
     "bb": [
       [
@@ -11075,8 +11080,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "4526"
+    "names": [
+      "Tomaszów Mazowiecki"
     ],
     "bb": [
       [
@@ -11114,8 +11119,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3908"
+    "names": [
+      "Skrzynki"
     ],
     "bb": [
       [
@@ -11153,8 +11158,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "5237"
+    "names": [
+      "Zaosie"
     ],
     "bb": [
       [
@@ -11192,8 +11197,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "5146"
+    "names": [
+      "Wykno"
     ],
     "bb": [
       [
@@ -11231,10 +11236,11 @@
     "prefix": "5377_ZP",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "5374",
-      "5376",
-      "5377"
+    "names": [
+      "Żakowice Południowe",
+      "Żakowice Płd Roz.5",
+      "Żakow. Płd Zieleń R7",
+      "Żakowice Południowe R7"
     ],
     "bb": [
       [
@@ -11272,8 +11278,8 @@
     "prefix": "2628_Mi",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2628"
+    "names": [
+      "Mikołajów"
     ],
     "bb": [
       [
@@ -11311,9 +11317,11 @@
     "prefix": "2439_LOC",
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2444",
-      "5694"
+    "names": [
+      "Łódź Olechów Łoc",
+      "Łódź Olechów R82",
+      "Łódź Olechów R91",
+      "Łódź Olechów PZS R82"
     ],
     "bb": [
       [
@@ -11383,9 +11391,8 @@
     "prefix": "2439_LOB",
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2443",
-      "5579"
+    "names": [
+      "Łódź Olechów PZS R16"
     ],
     "bb": [
       [
@@ -11447,9 +11454,9 @@
     "prefix": "2439_LOA",
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2442",
-      "5577"
+    "names": [
+      "Łódź Olechów R3",
+      "Łódź Olechów PZS R3"
     ],
     "bb": [
       [
@@ -11503,8 +11510,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "2452"
+    "names": [
+      "Łódź Olechów Wschód"
     ],
     "bb": [
       [
@@ -11542,9 +11549,9 @@
     "prefix": "2426_LCH",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2425",
-      "2426"
+    "names": [
+      "Łódź Chojny",
+      "Łódź Chojny R82"
     ],
     "bb": [
       [
@@ -11582,8 +11589,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "3213"
+    "names": [
+      "Piława Górna"
     ],
     "bb": [
       [
@@ -11621,8 +11628,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "5272"
+    "names": [
+      "Ząbkowice Śląskie"
     ],
     "bb": [
       [
@@ -11660,10 +11667,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4708",
-      "4709",
-      "4715"
+    "names": [
+      "Warszawa Gdańska"
     ],
     "bb": [
       [
@@ -11701,8 +11706,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "5472"
+    "names": [
+      "Warszawa Powązki"
     ],
     "bb": [
       [
@@ -11740,8 +11745,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4740"
+    "names": [
+      "Warszawa Koło"
     ],
     "bb": [
       [
@@ -11779,8 +11784,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4744"
+    "names": [
+      "Warszawa Młynów"
     ],
     "bb": [
       [
@@ -11818,8 +11823,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4815"
+    "names": [
+      "Warszawa Wola"
     ],
     "bb": [
       [
@@ -11857,10 +11862,11 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4718",
-      "4719",
-      "4723"
+    "names": [
+      "Warszawa Główna Towarowa",
+      "Warszawa Główna Towarowa WOA",
+      "Warszawa Gł.Tow.Sr18",
+      "Warszawa Gł.Tow. WOA"
     ],
     "bb": [
       [
@@ -11898,9 +11904,9 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "4569",
-      "4578"
+    "names": [
+      "Trzebinia",
+      "Trzebinia TSA"
     ],
     "bb": [
       [
@@ -11938,8 +11944,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": true,
-    "ids": [
-      "67"
+    "names": [
+      "Balin"
     ],
     "bb": [
       [
@@ -11977,8 +11983,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": true,
-    "ids": [
-      "1470"
+    "names": [
+      "Jaworzno Ciężkowice"
     ],
     "bb": [
       [
@@ -12016,11 +12022,8 @@
     "prefix": "MW",
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "2762",
-      "2773",
-      "2774",
-      "2775"
+    "names": [
+      "Mysłowice"
     ],
     "bb": [
       [
@@ -12058,8 +12061,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3995"
+    "names": [
+      "Sosnowiec Jęzor"
     ],
     "bb": [
       [
@@ -12097,8 +12100,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": true,
-    "ids": [
-      "858"
+    "names": [
+      "Dulowa"
     ],
     "bb": [
       [
@@ -12136,8 +12139,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": true,
-    "ids": [
-      "5004"
+    "names": [
+      "Wola Filipowska"
     ],
     "bb": [
       [
@@ -12175,9 +12178,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "2088",
-      "2089"
+    "names": [
+      "Krzeszowice"
     ],
     "bb": [
       [
@@ -12215,8 +12217,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3650"
+    "names": [
+      "Rudawa"
     ],
     "bb": [
       [
@@ -12254,8 +12256,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5163"
+    "names": [
+      "Zabierzów"
     ],
     "bb": [
       [
@@ -12293,8 +12295,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1951"
+    "names": [
+      "Kraków Business Park"
     ],
     "bb": [
       [
@@ -12332,8 +12334,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1982"
+    "names": [
+      "Kraków Mydlniki Wapiennik"
     ],
     "bb": [
       [
@@ -12371,9 +12373,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1971",
-      "1973"
+    "names": [
+      "Kraków Mydlniki"
     ],
     "bb": [
       [
@@ -12411,8 +12412,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1950"
+    "names": [
+      "Kraków Bronowice"
     ],
     "bb": [
       [
@@ -12450,9 +12451,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "1960",
-      "5465"
+    "names": [
+      "Kraków Główny Towarowy"
     ],
     "bb": [
       [
@@ -12490,9 +12490,9 @@
     "prefix": "DTA",
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "728",
-      "729"
+    "names": [
+      "Dąbrowa Górnicza Towarowa DTA",
+      "Dąbrowa Górnicza Towarowa"
     ],
     "bb": [
       [
@@ -12530,8 +12530,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "676"
+    "names": [
+      "Częstochowa Mirów"
     ],
     "bb": [
       [
@@ -12569,8 +12569,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2100"
+    "names": [
+      "Krzywizna"
     ],
     "bb": [
       [
@@ -12608,8 +12608,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "392"
+    "names": [
+      "Byczyna Kluczborska"
     ],
     "bb": [
       [
@@ -12647,8 +12647,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1866"
+    "names": [
+      "Kostów"
     ],
     "bb": [
       [
@@ -12686,8 +12686,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2389"
+    "names": [
+      "Łęka Opatowska"
     ],
     "bb": [
       [
@@ -12725,8 +12725,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1688"
+    "names": [
+      "Kępno"
     ],
     "bb": [
       [
@@ -12764,8 +12764,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1303"
+    "names": [
+      "Hanulin"
     ],
     "bb": [
       [
@@ -12803,8 +12803,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "826"
+    "names": [
+      "Domanin"
     ],
     "bb": [
       [
@@ -12842,8 +12842,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3067"
+    "names": [
+      "Ostrzeszów"
     ],
     "bb": [
       [
@@ -12881,8 +12881,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "41"
+    "names": [
+      "Antonin"
     ],
     "bb": [
       [
@@ -12920,8 +12920,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3421"
+    "names": [
+      "Przygodzice"
     ],
     "bb": [
       [
@@ -12959,9 +12959,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3060",
-      "3064"
+    "names": [
+      "Ostrów Wielkopolski"
     ],
     "bb": [
       [
@@ -12999,8 +12998,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "212"
+    "names": [
+      "Biniew"
     ],
     "bb": [
       [
@@ -13038,8 +13037,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "327"
+    "names": [
+      "Bronów"
     ],
     "bb": [
       [
@@ -13077,8 +13076,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4435"
+    "names": [
+      "Taczanów"
     ],
     "bb": [
       [
@@ -13116,8 +13115,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3236"
+    "names": [
+      "Pleszew"
     ],
     "bb": [
       [
@@ -13155,8 +13154,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1897"
+    "names": [
+      "Kotlin"
     ],
     "bb": [
       [
@@ -13194,8 +13193,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4966"
+    "names": [
+      "Witaszyce"
     ],
     "bb": [
       [
@@ -13233,8 +13232,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1417"
+    "names": [
+      "Jarocin"
     ],
     "bb": [
       [
@@ -13272,8 +13271,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2609"
+    "names": [
+      "Mieszków"
     ],
     "bb": [
       [
@@ -13311,8 +13310,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "476"
+    "names": [
+      "Chocicza"
     ],
     "bb": [
       [
@@ -13350,8 +13349,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4203"
+    "names": [
+      "Sulęcinek"
     ],
     "bb": [
       [
@@ -13389,8 +13388,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4391"
+    "names": [
+      "Środa Wielkopolska"
     ],
     "bb": [
       [
@@ -13428,8 +13427,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3187"
+    "names": [
+      "Pierzchno"
     ],
     "bb": [
       [
@@ -13467,8 +13466,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "942"
+    "names": [
+      "Gądki"
     ],
     "bb": [
       [
@@ -13506,8 +13505,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3341"
+    "names": [
+      "Poznań Krzesiny"
     ],
     "bb": [
       [
@@ -13545,9 +13544,9 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3346",
-      "3348"
+    "names": [
+      "Poznań Starołęka",
+      "Poznań Star. pzs Psk2"
     ],
     "bb": [
       [
@@ -13585,8 +13584,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3332"
+    "names": [
+      "Poznań Główny"
     ],
     "bb": [
       [
@@ -13624,8 +13623,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "2144"
+    "names": [
+      "Kuźnica Białostocka"
     ],
     "bb": [
       [
@@ -13663,8 +13662,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3971"
+    "names": [
+      "Sokółka"
     ],
     "bb": [
       [
@@ -13702,8 +13701,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "2488"
+    "names": [
+      "Machnacz"
     ],
     "bb": [
       [
@@ -13741,8 +13740,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "610"
+    "names": [
+      "Czarna Białostocka"
     ],
     "bb": [
       [
@@ -13780,8 +13779,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "4848"
+    "names": [
+      "Wasilków"
     ],
     "bb": [
       [
@@ -13819,8 +13818,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": false,
-    "ids": [
-      "159"
+    "names": [
+      "Białystok Gt-Ko"
     ],
     "bb": [
       [
@@ -13858,8 +13857,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "63"
+    "names": [
+      "Baciuty"
     ],
     "bb": [
       [
@@ -13897,8 +13896,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2356"
+    "names": [
+      "Łapy"
     ],
     "bb": [
       [
@@ -13936,8 +13935,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3478"
+    "names": [
+      "Racibory"
     ],
     "bb": [
       [
@@ -13975,8 +13974,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4340"
+    "names": [
+      "Szepietowo"
     ],
     "bb": [
       [
@@ -14014,9 +14013,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "693",
-      "694"
+    "names": [
+      "Czyżew GT",
+      "Czyżew"
     ],
     "bb": [
       [
@@ -14054,8 +14053,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1721"
+    "names": [
+      "Kietlanka"
     ],
     "bb": [
       [
@@ -14093,8 +14092,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2526"
+    "names": [
+      "Małkinia"
     ],
     "bb": [
       [
@@ -14132,8 +14131,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2393"
+    "names": [
+      "Łochów"
     ],
     "bb": [
       [
@@ -14171,8 +14170,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4517"
+    "names": [
+      "Tłuszcz"
     ],
     "bb": [
       [
@@ -14210,9 +14209,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5020",
-      "5023"
+    "names": [
+      "Wołomin Wschód PZS",
+      "Wołomin"
     ],
     "bb": [
       [
@@ -14250,8 +14249,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": false,
-    "ids": [
-      "5333"
+    "names": [
+      "Zielonka"
     ],
     "bb": [
       [
@@ -14289,8 +14288,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "4795"
+    "names": [
+      "Warszawa Rembertów"
     ],
     "bb": [
       [
@@ -14328,8 +14327,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4825"
+    "names": [
+      "Warszawa Wschodnia Towarowa"
     ],
     "bb": [
       [
@@ -14367,11 +14366,10 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "4762",
-      "4785",
-      "4787",
-      "4788"
+    "names": [
+      "Warszawa Praga WPT M",
+      "Warszawa Praga PZS R15",
+      "Warszawa Praga WPT C"
     ],
     "bb": [
       [
@@ -14409,8 +14407,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4735"
+    "names": [
+      "Warszawa Jelonki"
     ],
     "bb": [
       [
@@ -14449,9 +14447,9 @@
     "max_speed": 120,
     "stop_place": false,
     "assume_correct_platform": true,
-    "ids": [
-      "3594",
-      "3595"
+    "names": [
+      "Rokiciny GT",
+      "Rokiciny"
     ],
     "bb": [
       [
@@ -14490,9 +14488,9 @@
     "max_speed": 120,
     "stop_place": false,
     "assume_correct_platform": true,
-    "ids": [
-      "60",
-      "61"
+    "names": [
+      "Baby",
+      "Baby GT"
     ],
     "bb": [
       [
@@ -14530,9 +14528,9 @@
     "prefix": "3223_PT",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3221",
-      "3223"
+    "names": [
+      "Piotrków Tryb Tow",
+      "Piotrków Trybunalski"
     ],
     "bb": [
       [
@@ -14570,8 +14568,8 @@
     "prefix": "3617_Ro",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3617"
+    "names": [
+      "Rozprza"
     ],
     "bb": [
       [
@@ -14609,9 +14607,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1153",
-      "1154"
+    "names": [
+      "Gorzkowice GT",
+      "Gorzkowice"
     ],
     "bb": [
       [
@@ -14649,9 +14647,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1140",
-      "1141"
+    "names": [
+      "Gomunice",
+      "Gomunice GT"
     ],
     "bb": [
       [
@@ -14689,9 +14687,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3509",
-      "3510"
+    "names": [
+      "Radomsko",
+      "Radomsko GT"
     ],
     "bb": [
       [
@@ -14729,8 +14727,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4890"
+    "names": [
+      "Widzów Teklinów"
     ],
     "bb": [
       [
@@ -14768,8 +14766,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1769"
+    "names": [
+      "Kłomnice"
     ],
     "bb": [
       [
@@ -14807,8 +14805,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3659"
+    "names": [
+      "Rudniki koło Częstochowy"
     ],
     "bb": [
       [
@@ -14846,8 +14844,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "284"
+    "names": [
+      "Boronów"
     ],
     "bb": [
       [
@@ -14885,8 +14883,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": true,
-    "ids": [
-      "4153"
+    "names": [
+      "Strzebiń"
     ],
     "bb": [
       [
@@ -14924,8 +14922,8 @@
     "prefix": null,
     "max_speed": 30,
     "stop_place": false,
-    "ids": [
-      "1558"
+    "names": [
+      "Kalety"
     ],
     "bb": [
       [
@@ -14963,8 +14961,8 @@
     "prefix": null,
     "max_speed": 30,
     "stop_place": true,
-    "ids": [
-      "5358"
+    "names": [
+      "Zwierzyniec"
     ],
     "bb": [
       [
@@ -15002,9 +15000,9 @@
     "prefix": null,
     "max_speed": 30,
     "stop_place": false,
-    "ids": [
-      "4469",
-      "4473"
+    "names": [
+      "Tarnowskie Góry",
+      "Tarnowskie Góry TGE"
     ],
     "bb": [
       [
@@ -15042,9 +15040,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "399",
-      "402"
+    "names": [
+      "Bydgoszcz Główna",
+      "Bydgoszcz Główna Towarowa"
     ],
     "bb": [
       [
@@ -15082,8 +15080,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "408"
+    "names": [
+      "Bydgoszcz Wschód Towarowa"
     ],
     "bb": [
       [
@@ -15121,8 +15119,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "406"
+    "names": [
+      "Bydgoszcz Wschód"
     ],
     "bb": [
       [
@@ -15160,8 +15158,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "403"
+    "names": [
+      "Bydgoszcz Leśna"
     ],
     "bb": [
       [
@@ -15199,8 +15197,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "404"
+    "names": [
+      "Bydgoszcz Łęgnowo"
     ],
     "bb": [
       [
@@ -15238,8 +15236,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3977"
+    "names": [
+      "Solec Kujawski"
     ],
     "bb": [
       [
@@ -15277,8 +15275,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3424"
+    "names": [
+      "Przyłubie"
     ],
     "bb": [
       [
@@ -15316,8 +15314,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "563"
+    "names": [
+      "Cierpice"
     ],
     "bb": [
       [
@@ -15355,9 +15353,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": false,
-    "ids": [
-      "4534",
-      "4539"
+    "names": [
+      "Toruń Główny"
     ],
     "bb": [
       [
@@ -15395,8 +15392,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3080"
+    "names": [
+      "Otłoczyn"
     ],
     "bb": [
       [
@@ -15434,8 +15431,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "34"
+    "names": [
+      "Aleksandrów Kujawski"
     ],
     "bb": [
       [
@@ -15473,8 +15470,8 @@
     "prefix": null,
     "max_speed": 125,
     "stop_place": false,
-    "ids": [
-      "2833"
+    "names": [
+      "Nieszawa Waganiec"
     ],
     "bb": [
       [
@@ -15512,8 +15509,8 @@
     "prefix": null,
     "max_speed": 125,
     "stop_place": true,
-    "ids": [
-      "2288"
+    "names": [
+      "Lubanie"
     ],
     "bb": [
       [
@@ -15551,8 +15548,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "4980"
+    "names": [
+      "Włocławek Brzezie"
     ],
     "bb": [
       [
@@ -15590,8 +15587,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4979"
+    "names": [
+      "Włocławek"
     ],
     "bb": [
       [
@@ -15629,8 +15626,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "646"
+    "names": [
+      "Czerniewice"
     ],
     "bb": [
       [
@@ -15668,8 +15665,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1565"
+    "names": [
+      "Kaliska Kujawskie"
     ],
     "bb": [
       [
@@ -15707,8 +15704,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3056"
+    "names": [
+      "Ostrowy"
     ],
     "bb": [
       [
@@ -15746,9 +15743,9 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2133",
-      "2138"
+    "names": [
+      "Kutno Wsch Tow Pprj",
+      "Kutno"
     ],
     "bb": [
       [
@@ -15786,8 +15783,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "4971"
+    "names": [
+      "Witonia"
     ],
     "bb": [
       [
@@ -15825,8 +15822,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "2385"
+    "names": [
+      "Łęczyca"
     ],
     "bb": [
       [
@@ -15864,8 +15861,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "3089"
+    "names": [
+      "Ozorków"
     ],
     "bb": [
       [
@@ -15903,8 +15900,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "477"
+    "names": [
+      "Chociszew"
     ],
     "bb": [
       [
@@ -15942,8 +15939,8 @@
     "prefix": "5314_ZP",
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "5314"
+    "names": [
+      "Zgierz Północ"
     ],
     "bb": [
       [
@@ -15981,8 +15978,8 @@
     "prefix": "5311_Zg",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "5311"
+    "names": [
+      "Zgierz"
     ],
     "bb": [
       [
@@ -16020,9 +16017,9 @@
     "prefix": "2463_LZ",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2463",
-      "2464"
+    "names": [
+      "Łódź Żabieniec",
+      "Łódź Żabieniec GT"
     ],
     "bb": [
       [
@@ -16060,11 +16057,8 @@
     "prefix": "2432_LK",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2432",
-      "2435",
-      "2436",
-      "5576"
+    "names": [
+      "Łódź Kaliska"
     ],
     "bb": [
       [
@@ -16102,8 +16096,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4667"
+    "names": [
+      "Wałbrzych Miasto"
     ],
     "bb": [
       [
@@ -16141,8 +16135,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "4546"
+    "names": [
+      "Toszek Północ"
     ],
     "bb": [
       [
@@ -16180,8 +16174,8 @@
     "prefix": null,
     "max_speed": 150,
     "stop_place": false,
-    "ids": [
-      "873"
+    "names": [
+      "Działdowo"
     ],
     "bb": [
       [
@@ -16219,8 +16213,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3441"
+    "names": [
+      "Pszczyna"
     ],
     "bb": [
       [
@@ -16258,8 +16252,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": false,
-    "ids": [
-      "3003"
+    "names": [
+      "Opole Groszowice"
     ],
     "bb": [
       [
@@ -16297,8 +16291,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "2911"
+    "names": [
+      "Nowy Targ"
     ],
     "bb": [
       [
@@ -16336,8 +16330,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "3310"
+    "names": [
+      "Poronin"
     ],
     "bb": [
       [
@@ -16375,8 +16369,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2800"
+    "names": [
+      "Nasielsk"
     ],
     "bb": [
       [
@@ -16414,8 +16408,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "1230"
+    "names": [
+      "Gralewo"
     ],
     "bb": [
       [
@@ -16453,8 +16447,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1734"
+    "names": [
+      "Klementowice"
     ],
     "bb": [
       [
@@ -16492,8 +16486,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "4186"
+    "names": [
+      "Sucha Beskidzka Zamek"
     ],
     "bb": [
       [
@@ -16531,8 +16525,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "5300"
+    "names": [
+      "Zdzieszowice"
     ],
     "bb": [
       [
@@ -16570,8 +16564,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2791"
+    "names": [
+      "Nałęczów"
     ],
     "bb": [
       [
@@ -16609,8 +16603,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "3529"
+    "names": [
+      "Radziszów"
     ],
     "bb": [
       [
@@ -16648,8 +16642,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1946"
+    "names": [
+      "Kraków Bonarka"
     ],
     "bb": [
       [
@@ -16687,8 +16681,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "4217"
+    "names": [
+      "Susz"
     ],
     "bb": [
       [
@@ -16726,8 +16720,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "186"
+    "names": [
+      "Bielsko-Biała Główna"
     ],
     "bb": [
       [
@@ -16765,8 +16759,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "1359"
+    "names": [
+      "Iłowo"
     ],
     "bb": [
       [
@@ -16804,8 +16798,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2310"
+    "names": [
+      "Lublin"
     ],
     "bb": [
       [
@@ -16843,9 +16837,9 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "952",
-      "5443"
+    "names": [
+      "Gdańsk Główny",
+      "Gdańsk Główny PZS R7-R510"
     ],
     "bb": [
       [
@@ -16883,8 +16877,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4669"
+    "names": [
+      "Wałbrzych Szczawienko"
     ],
     "bb": [
       [
@@ -16922,8 +16916,8 @@
     "prefix": null,
     "max_speed": 30,
     "stop_place": false,
-    "ids": [
-      "628"
+    "names": [
+      "Czechowice-Dziedzice"
     ],
     "bb": [
       [
@@ -16961,8 +16955,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5202"
+    "names": [
+      "Zajączkowo Lubawskie"
     ],
     "bb": [
       [
@@ -17000,8 +16994,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "4241"
+    "names": [
+      "Szaflary"
     ],
     "bb": [
       [
@@ -17039,8 +17033,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3219"
+    "names": [
+      "Pionki Zachodnie"
     ],
     "bb": [
       [
@@ -17078,8 +17072,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "1837"
+    "names": [
+      "Konopki"
     ],
     "bb": [
       [
@@ -17117,8 +17111,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1414"
+    "names": [
+      "Janowice Wielkie"
     ],
     "bb": [
       [
@@ -17156,8 +17150,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2677"
+    "names": [
+      "Mleczewo"
     ],
     "bb": [
       [
@@ -17195,8 +17189,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1501"
+    "names": [
+      "Jelenia Góra"
     ],
     "bb": [
       [
@@ -17234,8 +17228,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1194"
+    "names": [
+      "Górażdże"
     ],
     "bb": [
       [
@@ -17273,8 +17267,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": false,
-    "ids": [
-      "1538"
+    "names": [
+      "Jordanów"
     ],
     "bb": [
       [
@@ -17312,8 +17306,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "2327"
+    "names": [
+      "Lublin Zachodni"
     ],
     "bb": [
       [
@@ -17351,8 +17345,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3770"
+    "names": [
+      "Sadurki"
     ],
     "bb": [
       [
@@ -17390,8 +17384,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5432"
+    "names": [
+      "Żytkowice"
     ],
     "bb": [
       [
@@ -17429,8 +17423,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "4415"
+    "names": [
+      "Świercze"
     ],
     "bb": [
       [
@@ -17468,9 +17462,9 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2504",
-      "2505"
+    "names": [
+      "Malbork",
+      "Malbork Grupa Tranzytowa"
     ],
     "bb": [
       [
@@ -17508,9 +17502,9 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3983",
-      "3984"
+    "names": [
+      "Sopot Grupa Tranzytowa",
+      "Sopot"
     ],
     "bb": [
       [
@@ -17548,8 +17542,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "5216"
+    "names": [
+      "Zajezierze koło Dęblina"
     ],
     "bb": [
       [
@@ -17587,8 +17581,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "3470"
+    "names": [
+      "Raba Wyżna"
     ],
     "bb": [
       [
@@ -17626,8 +17620,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "150"
+    "names": [
+      "Biały Dunajec"
     ],
     "bb": [
       [
@@ -17665,8 +17659,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "3870"
+    "names": [
+      "Skawina"
     ],
     "bb": [
       [
@@ -17704,8 +17698,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "3710"
+    "names": [
+      "Rybno Pomorskie"
     ],
     "bb": [
       [
@@ -17743,8 +17737,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "103"
+    "names": [
+      "Bąkowiec"
     ],
     "bb": [
       [
@@ -17782,8 +17776,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "629"
+    "names": [
+      "Czechowice-Dziedzice Południowe"
     ],
     "bb": [
       [
@@ -17821,8 +17815,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "3036"
+    "names": [
+      "Osielec"
     ],
     "bb": [
       [
@@ -17860,8 +17854,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3793"
+    "names": [
+      "Sędzisław"
     ],
     "bb": [
       [
@@ -17899,8 +17893,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4145"
+    "names": [
+      "Stryszów"
     ],
     "bb": [
       [
@@ -17938,8 +17932,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "255"
+    "names": [
+      "Boguszów-Gorce Wschód"
     ],
     "bb": [
       [
@@ -17977,8 +17971,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "5247"
+    "names": [
+      "Zarzeka"
     ],
     "bb": [
       [
@@ -18016,8 +18010,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "1575"
+    "names": [
+      "Kalwaria Zebrzydowska Lanckorona"
     ],
     "bb": [
       [
@@ -18055,8 +18049,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4727"
+    "names": [
+      "Warszawa Gołąbki"
     ],
     "bb": [
       [
@@ -18094,8 +18088,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "4664"
+    "names": [
+      "Wałbrzych Fabryczny"
     ],
     "bb": [
       [
@@ -18133,8 +18127,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "3563"
+    "names": [
+      "Redaki"
     ],
     "bb": [
       [
@@ -18172,8 +18166,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1020"
+    "names": [
+      "Gdynia Orłowo"
     ],
     "bb": [
       [
@@ -18211,8 +18205,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4799"
+    "names": [
+      "Warszawa Śródmieście"
     ],
     "bb": [
       [
@@ -18250,8 +18244,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5381"
+    "names": [
+      "Żarów"
     ],
     "bb": [
       [
@@ -18289,8 +18283,8 @@
     "prefix": null,
     "max_speed": 125,
     "stop_place": true,
-    "ids": [
-      "3454"
+    "names": [
+      "Puławy Miasto"
     ],
     "bb": [
       [
@@ -18328,8 +18322,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "549"
+    "names": [
+      "Ciechanów"
     ],
     "bb": [
       [
@@ -18367,8 +18361,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2679"
+    "names": [
+      "Mława"
     ],
     "bb": [
       [
@@ -18406,9 +18400,9 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "661",
-      "5439"
+    "names": [
+      "Czerwionka",
+      "Czerwionka PZS R20"
     ],
     "bb": [
       [
@@ -18446,8 +18440,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2544"
+    "names": [
+      "Marciszów"
     ],
     "bb": [
       [
@@ -18485,8 +18479,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "2167"
+    "names": [
+      "Lasek"
     ],
     "bb": [
       [
@@ -18524,8 +18518,8 @@
     "prefix": null,
     "max_speed": 125,
     "stop_place": false,
-    "ids": [
-      "3452"
+    "names": [
+      "Puławy Azoty"
     ],
     "bb": [
       [
@@ -18563,8 +18557,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "2010"
+    "names": [
+      "Kraków Podgórze"
     ],
     "bb": [
       [
@@ -18602,8 +18596,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4746"
+    "names": [
+      "Warszawa Ochota"
     ],
     "bb": [
       [
@@ -18657,8 +18651,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "2030"
+    "names": [
+      "Kraków Zabłocie"
     ],
     "bb": [
       [
@@ -18696,8 +18690,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "258"
+    "names": [
+      "Boguszów-Gorce Zachód"
     ],
     "bb": [
       [
@@ -18735,8 +18729,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "3823"
+    "names": [
+      "Sieniawa"
     ],
     "bb": [
       [
@@ -18774,8 +18768,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "926"
+    "names": [
+      "Garbatka-Letnisko"
     ],
     "bb": [
       [
@@ -18813,8 +18807,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": true,
-    "ids": [
-      "3548"
+    "names": [
+      "Raszowa"
     ],
     "bb": [
       [
@@ -18852,8 +18846,8 @@
     "prefix": null,
     "max_speed": 150,
     "stop_place": false,
-    "ids": [
-      "3357"
+    "names": [
+      "Prabuty"
     ],
     "bb": [
       [
@@ -18891,8 +18885,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "4804"
+    "names": [
+      "Warszawa Ursus Północny"
     ],
     "bb": [
       [
@@ -18930,8 +18924,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "4371"
+    "names": [
+      "Szymankowo"
     ],
     "bb": [
       [
@@ -18969,8 +18963,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "966"
+    "names": [
+      "Gdańsk Oliwa"
     ],
     "bb": [
       [
@@ -19008,8 +19002,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "3541"
+    "names": [
+      "Rakowice"
     ],
     "bb": [
       [
@@ -19047,8 +19041,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3946"
+    "names": [
+      "Smolec"
     ],
     "bb": [
       [
@@ -19086,8 +19080,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "3092"
+    "names": [
+      "Ożarów Mazowiecki"
     ],
     "bb": [
       [
@@ -19125,8 +19119,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1360"
+    "names": [
+      "Imbramowice"
     ],
     "bb": [
       [
@@ -19164,8 +19158,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1495"
+    "names": [
+      "Jedlnia-Letnisko"
     ],
     "bb": [
       [
@@ -19203,8 +19197,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3218"
+    "names": [
+      "Pionki"
     ],
     "bb": [
       [
@@ -19242,8 +19236,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "5334"
+    "names": [
+      "Zielonka Bankowa"
     ],
     "bb": [
       [
@@ -19281,8 +19275,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "4745"
+    "names": [
+      "Warszawa Mokry Ług"
     ],
     "bb": [
       [
@@ -19320,8 +19314,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4666"
+    "names": [
+      "Wałbrzych Główny"
     ],
     "bb": [
       [
@@ -19359,9 +19353,9 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "4494",
-      "5440"
+    "names": [
+      "Tczew",
+      "Tczew PZS R11"
     ],
     "bb": [
       [
@@ -19399,9 +19393,9 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "995",
-      "996"
+    "names": [
+      "Gdańsk Wrzeszcz Grupa Tranzytowa",
+      "Gdańsk Wrzeszcz"
     ],
     "bb": [
       [
@@ -19439,8 +19433,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1484"
+    "names": [
+      "Jaworzyna Śląska"
     ],
     "bb": [
       [
@@ -19478,8 +19472,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1124"
+    "names": [
+      "Gogolin"
     ],
     "bb": [
       [
@@ -19517,8 +19511,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4759"
+    "names": [
+      "Warszawa Powiśle"
     ],
     "bb": [
       [
@@ -19564,8 +19558,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2703"
+    "names": [
+      "Montowo"
     ],
     "bb": [
       [
@@ -19603,8 +19597,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "4797"
+    "names": [
+      "Warszawa Stadion"
     ],
     "bb": [
       [
@@ -19642,8 +19636,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": true,
-    "ids": [
-      "5218"
+    "names": [
+      "Zakopane"
     ],
     "bb": [
       [
@@ -19681,8 +19675,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2369"
+    "names": [
+      "Łaziska Średnie"
     ],
     "bb": [
       [
@@ -19720,8 +19714,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "253"
+    "names": [
+      "Boguszów-Gorce"
     ],
     "bb": [
       [
@@ -19759,8 +19753,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2179"
+    "names": [
+      "Legionowo"
     ],
     "bb": [
       [
@@ -19798,8 +19792,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3451"
+    "names": [
+      "Puławy"
     ],
     "bb": [
       [
@@ -19837,8 +19831,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": true,
-    "ids": [
-      "1780"
+    "names": [
+      "Kobiór"
     ],
     "bb": [
       [
@@ -19876,9 +19870,9 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "1012",
-      "1013"
+    "names": [
+      "Gdynia Główna",
+      "Gdynia Gł. Roz.84"
     ],
     "bb": [
       [
@@ -19916,8 +19910,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "4409"
+    "names": [
+      "Świebodzice"
     ],
     "bb": [
       [
@@ -19955,8 +19949,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2732"
+    "names": [
+      "Motycz"
     ],
     "bb": [
       [
@@ -19994,8 +19988,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "1439"
+    "names": [
+      "Jasiona"
     ],
     "bb": [
       [
@@ -20033,8 +20027,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "947"
+    "names": [
+      "Gąsocin"
     ],
     "bb": [
       [
@@ -20072,9 +20066,9 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "2894",
-      "2895"
+    "names": [
+      "Nowy Dwór Mazowiecki GT",
+      "Nowy Dwór Mazowiecki"
     ],
     "bb": [
       [
@@ -20112,8 +20106,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "4132"
+    "names": [
+      "Stronie"
     ],
     "bb": [
       [
@@ -20151,8 +20145,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": false,
-    "ids": [
-      "2688"
+    "names": [
+      "Modlin"
     ],
     "bb": [
       [
@@ -20190,8 +20184,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "5122"
+    "names": [
+      "Wrocław Zachodni"
     ],
     "bb": [
       [
@@ -20229,8 +20223,8 @@
     "prefix": null,
     "max_speed": 130,
     "stop_place": false,
-    "ids": [
-      "1662"
+    "names": [
+      "Kąty Wrocławskie"
     ],
     "bb": [
       [
@@ -20268,8 +20262,8 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "3439"
+    "names": [
+      "Pszczółki"
     ],
     "bb": [
       [
@@ -20307,8 +20301,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "4995"
+    "names": [
+      "Wojanów"
     ],
     "bb": [
       [
@@ -20346,8 +20340,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3435"
+    "names": [
+      "Przywory Opolskie"
     ],
     "bb": [
       [
@@ -20385,9 +20379,10 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1927",
-      "2003"
+    "names": [
+      "Kraków Płaszów",
+      "Kraków Płaszów R3-4",
+      "Kr.Płaszów pzs KPA"
     ],
     "bb": [
       [
@@ -20425,8 +20420,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2502"
+    "names": [
+      "Maków Podhalański"
     ],
     "bb": [
       [
@@ -20464,9 +20459,9 @@
     "prefix": null,
     "max_speed": 160,
     "stop_place": false,
-    "ids": [
-      "3376",
-      "5442"
+    "names": [
+      "Pruszcz Gdański PZS R73-75",
+      "Pruszcz Gdański"
     ],
     "bb": [
       [
@@ -20504,8 +20499,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2198"
+    "names": [
+      "Leńcze"
     ],
     "bb": [
       [
@@ -20543,8 +20538,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "3023"
+    "names": [
+      "Orzesze Jaśkowice"
     ],
     "bb": [
       [
@@ -20582,8 +20577,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "980"
+    "names": [
+      "Gdańsk Południowy"
     ],
     "bb": [
       [
@@ -20621,9 +20616,9 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "1354",
-      "5441"
+    "names": [
+      "Iława Główna",
+      "Iława Główna PZS R1-R2"
     ],
     "bb": [
       [
@@ -20661,8 +20656,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "498"
+    "names": [
+      "Chorzew Siemkowice"
     ],
     "bb": [
       [
@@ -20700,9 +20695,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3268",
-      "3269"
+    "names": [
+      "Podłęże",
+      "Podłęże R101"
     ],
     "bb": [
       [
@@ -20740,8 +20735,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "354"
+    "names": [
+      "Brzeźnica nad Wartą"
     ],
     "bb": [
       [
@@ -20779,8 +20774,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "131"
+    "names": [
+      "Biadoliny"
     ],
     "bb": [
       [
@@ -20818,9 +20813,9 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "1998",
-      "1999"
+    "names": [
+      "Kraków Olsza",
+      "Kraków Olsza R2"
     ],
     "bb": [
       [
@@ -20858,8 +20853,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "239"
+    "names": [
+      "Bochnia"
     ],
     "bb": [
       [
@@ -20897,8 +20892,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "591"
+    "names": [
+      "Cykarzew"
     ],
     "bb": [
       [
@@ -20936,9 +20931,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "341",
-      "342"
+    "names": [
+      "Brzesko Okocim",
+      "Brzesko Okocim GT"
     ],
     "bb": [
       [
@@ -20976,8 +20971,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "5009"
+    "names": [
+      "Wola Rzędzińska"
     ],
     "bb": [
       [
@@ -21015,8 +21010,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "251"
+    "names": [
+      "Bogumiłowice"
     ],
     "bb": [
       [
@@ -21054,8 +21049,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4483"
+    "names": [
+      "Tarnów Mościce"
     ],
     "bb": [
       [
@@ -21093,8 +21088,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4478"
+    "names": [
+      "Tarnów"
     ],
     "bb": [
       [
@@ -21132,8 +21127,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1753"
+    "names": [
+      "Kłaj"
     ],
     "bb": [
       [
@@ -21171,8 +21166,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "134"
+    "names": [
+      "Biała Pajęczańska"
     ],
     "bb": [
       [
@@ -21210,9 +21205,9 @@
     "prefix": "KPm",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "2020",
-      "2021"
+    "names": [
+      "Kraków Przedmieście R3",
+      "Kraków Przedmieście"
     ],
     "bb": [
       [
@@ -21250,8 +21245,8 @@
     "prefix": "Rc",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "3475"
+    "names": [
+      "Raciborowice"
     ],
     "bb": [
       [
@@ -21289,8 +21284,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "292"
+    "names": [
+      "Borszewice"
     ],
     "bb": [
       [
@@ -21328,8 +21323,8 @@
     "prefix": "2360_La",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "2360"
+    "names": [
+      "Łask"
     ],
     "bb": [
       [
@@ -21367,8 +21362,8 @@
     "prefix": "3792_Se",
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3792"
+    "names": [
+      "Sędzice"
     ],
     "bb": [
       [
@@ -21406,8 +21401,8 @@
     "prefix": "2330_Lb",
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "2330"
+    "names": [
+      "Łódź Lublinek"
     ],
     "bb": [
       [
@@ -21445,8 +21440,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "802"
+    "names": [
+      "Dobroń"
     ],
     "bb": [
       [
@@ -21484,8 +21479,8 @@
     "prefix": "5291_ZW",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "5291"
+    "names": [
+      "Zduńska Wola"
     ],
     "bb": [
       [
@@ -21523,8 +21518,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1566"
+    "names": [
+      "Kalisz"
     ],
     "bb": [
       [
@@ -21562,8 +21557,8 @@
     "prefix": "3827_Si",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3827"
+    "names": [
+      "Sieradz"
     ],
     "bb": [
       [
@@ -21601,8 +21596,8 @@
     "prefix": "3093_Pa",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "3093"
+    "names": [
+      "Pabianice"
     ],
     "bb": [
       [
@@ -21640,8 +21635,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2877"
+    "names": [
+      "Nowe Skalmierzyce"
     ],
     "bb": [
       [
@@ -21679,8 +21674,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3492"
+    "names": [
+      "Radliczyce"
     ],
     "bb": [
       [
@@ -21718,8 +21713,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "225"
+    "names": [
+      "Błaszki"
     ],
     "bb": [
       [
@@ -21757,8 +21752,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "632"
+    "names": [
+      "Czekanów"
     ],
     "bb": [
       [
@@ -21796,8 +21791,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2991"
+    "names": [
+      "Opatówek"
     ],
     "bb": [
       [
@@ -21835,8 +21830,8 @@
     "prefix": "Ms",
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "2744"
+    "names": [
+      "Mszczonów"
     ],
     "bb": [
       [
@@ -21874,8 +21869,8 @@
     "prefix": "Mr",
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "2547"
+    "names": [
+      "Marków"
     ],
     "bb": [
       [
@@ -21903,7 +21898,7 @@
     "osm_id": 1991393715,
     "uic_ref": null,
     "position": {
-      "lat": 51.9680200,
+      "lat": 51.96802,
       "lng": 20.4988349
     }
   },
@@ -21913,8 +21908,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4614"
+    "names": [
+      "Twardogóra"
     ],
     "bb": [
       [
@@ -21942,7 +21937,7 @@
     "osm_id": 3322950957,
     "uic_ref": "5103867",
     "position": {
-      "lat": 51.3602630,
+      "lat": 51.360263,
       "lng": 17.4677429
     }
   },
@@ -21952,8 +21947,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "804"
+    "names": [
+      "Dobroszyce"
     ],
     "bb": [
       [
@@ -21991,8 +21986,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1223"
+    "names": [
+      "Grabowno Wielkie"
     ],
     "bb": [
       [
@@ -22020,8 +22015,8 @@
     "osm_id": 2003311924,
     "uic_ref": "5101082",
     "position": {
-      "lat": 51.3432200,
-      "lng": 17.4034740
+      "lat": 51.34322,
+      "lng": 17.403474
     }
   },
   {
@@ -22030,8 +22025,8 @@
     "prefix": "113_Be",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "113"
+    "names": [
+      "Bełchów"
     ],
     "bb": [
       [
@@ -22060,7 +22055,7 @@
     "uic_ref": "5100411",
     "position": {
       "lat": 52.0264867,
-      "lng": 20.0331400
+      "lng": 20.03314
     }
   },
   {
@@ -22069,8 +22064,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "742"
+    "names": [
+      "Dąbrowa Oleśnicka"
     ],
     "bb": [
       [
@@ -22108,8 +22103,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4529"
+    "names": [
+      "Topola-Osiedle"
     ],
     "bb": [
       [
@@ -22147,8 +22142,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2940"
+    "names": [
+      "Odolanów"
     ],
     "bb": [
       [
@@ -22176,7 +22171,7 @@
     "osm_id": 10218344847,
     "uic_ref": "5102538",
     "position": {
-      "lat": 51.5745910,
+      "lat": 51.574591,
       "lng": 17.6677164
     }
   },
@@ -22186,8 +22181,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "2965"
+    "names": [
+      "Oleśnica Rataje"
     ],
     "bb": [
       [
@@ -22225,8 +22220,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "5076"
+    "names": [
+      "Wrocław Mikołajów"
     ],
     "bb": [
       [
@@ -22255,7 +22250,7 @@
     "uic_ref": "5104134",
     "position": {
       "lat": 51.1162965,
-      "lng": 16.9983950
+      "lng": 16.998395
     }
   },
   {
@@ -22264,8 +22259,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4014"
+    "names": [
+      "Sośnie Ostrowskie"
     ],
     "bb": [
       [
@@ -22303,8 +22298,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "154"
+    "names": [
+      "Białystok"
     ],
     "bb": [
       [
@@ -22342,8 +22337,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1233"
+    "names": [
+      "Granowiec"
     ],
     "bb": [
       [
@@ -22381,8 +22376,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2431"
+    "names": [
+      "Łódź Fabryczna"
     ],
     "bb": [
       [
@@ -22420,8 +22415,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": false,
-    "ids": [
-      "2519"
+    "names": [
+      "Małaszewicze Centralne"
     ],
     "bb": [
       [
@@ -22459,8 +22454,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "137"
+    "names": [
+      "Biała Podlaska Rozrządowa"
     ],
     "bb": [
       [
@@ -22506,8 +22501,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "644"
+    "names": [
+      "Czernica Wrocławska"
     ],
     "bb": [
       [
@@ -22545,8 +22540,9 @@
     "prefix": "3928_Sl",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3928"
+    "names": [
+      "Słotwiny",
+      "Słotwiny R1"
     ],
     "bb": [
       [
@@ -22584,8 +22580,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2996"
+    "names": [
+      "Opole Czarnowąsy"
     ],
     "bb": [
       [
@@ -22623,8 +22619,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1275"
+    "names": [
+      "Grzebowilk"
     ],
     "bb": [
       [
@@ -22653,7 +22649,7 @@
     "uic_ref": null,
     "position": {
       "lat": 52.1155147,
-      "lng": 21.5335210
+      "lng": 21.533521
     }
   },
   {
@@ -22662,8 +22658,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "4121"
+    "names": [
+      "Stoczek Łukowski"
     ],
     "bb": [
       [
@@ -22701,8 +22697,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3976"
+    "names": [
+      "Sokule"
     ],
     "bb": [
       [
@@ -22740,8 +22736,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": false,
-    "ids": [
-      "601"
+    "names": [
+      "Czachówek Wschodni"
     ],
     "bb": [
       [
@@ -22770,7 +22766,7 @@
     "uic_ref": "5100858",
     "position": {
       "lat": 51.9734724,
-      "lng": 21.1042080
+      "lng": 21.104208
     }
   },
   {
@@ -22779,8 +22775,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "4441"
+    "names": [
+      "Tarczyn"
     ],
     "bb": [
       [
@@ -22818,9 +22814,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2473",
-      "2475"
+    "names": [
+      "Łuków P",
+      "Łuków"
     ],
     "bb": [
       [
@@ -22858,12 +22854,12 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5044",
-      "5047",
-      "5049",
-      "5051",
-      "5053"
+    "names": [
+      "Wrocław Brochów Wbb",
+      "Wrocław Brochów Wbaf",
+      "Wrocław Brochów Wbbe",
+      "Wrocław Brochów PODG",
+      "Wrocław Brochów Wba"
     ],
     "bb": [
       [
@@ -22901,8 +22897,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3303"
+    "names": [
+      "Popielów"
     ],
     "bb": [
       [
@@ -22940,8 +22936,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "217"
+    "names": [
+      "Biskupice Oławskie"
     ],
     "bb": [
       [
@@ -22979,8 +22975,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "5406"
+    "names": [
+      "Żórawina"
     ],
     "bb": [
       [
@@ -23018,8 +23014,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "235"
+    "names": [
+      "Bobrowniki"
     ],
     "bb": [
       [
@@ -23047,8 +23043,8 @@
     "osm_id": 2181005144,
     "uic_ref": "5100530",
     "position": {
-      "lat": 52.0585800,
-      "lng": 20.0104100
+      "lat": 52.05858,
+      "lng": 20.01041
     }
   },
   {
@@ -23057,8 +23053,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": false,
-    "ids": [
-      "3801"
+    "names": [
+      "Siechnice"
     ],
     "bb": [
       [
@@ -23096,8 +23092,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4247"
+    "names": [
+      "Szaniawy"
     ],
     "bb": [
       [
@@ -23135,8 +23131,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "277"
+    "names": [
+      "Boreczek"
     ],
     "bb": [
       [
@@ -23165,7 +23161,7 @@
     "uic_ref": "5100548",
     "position": {
       "lat": 50.8789262,
-      "lng": 17.0245800
+      "lng": 17.02458
     }
   },
   {
@@ -23174,8 +23170,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2619"
+    "names": [
+      "Międzyrzec Podlaski"
     ],
     "bb": [
       [
@@ -23213,8 +23209,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "1189"
+    "names": [
+      "Góra Kalwaria"
     ],
     "bb": [
       [
@@ -23252,8 +23248,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2412"
+    "names": [
+      "Łowicz Główny"
     ],
     "bb": [
       [
@@ -23281,7 +23277,7 @@
     "osm_id": 1277279650,
     "uic_ref": "5100167",
     "position": {
-      "lat": 52.1047300,
+      "lat": 52.10473,
       "lng": 19.9556222
     }
   },
@@ -23291,8 +23287,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "511"
+    "names": [
+      "Chotyłów"
     ],
     "bb": [
       [
@@ -23321,7 +23317,7 @@
     "uic_ref": "5100828",
     "position": {
       "lat": 51.9968432,
-      "lng": 23.3558230
+      "lng": 23.355823
     }
   },
   {
@@ -23330,8 +23326,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1311"
+    "names": [
+      "Henryków"
     ],
     "bb": [
       [
@@ -23369,8 +23365,8 @@
     "prefix": "3459_PM",
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "3459"
+    "names": [
+      "Puszcza Mariańska"
     ],
     "bb": [
       [
@@ -23408,8 +23404,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "136"
+    "names": [
+      "Biała Podlaska"
     ],
     "bb": [
       [
@@ -23447,8 +23443,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4161"
+    "names": [
+      "Strzelin"
     ],
     "bb": [
       [
@@ -23486,8 +23482,8 @@
     "prefix": null,
     "max_speed": 50,
     "stop_place": false,
-    "ids": [
-      "3032"
+    "names": [
+      "Osieck"
     ],
     "bb": [
       [
@@ -23515,7 +23511,7 @@
     "osm_id": 3458961439,
     "uic_ref": null,
     "position": {
-      "lat": 51.9773100,
+      "lat": 51.97731,
       "lng": 21.4127955
     }
   },
@@ -23525,8 +23521,8 @@
     "prefix": null,
     "max_speed": 40,
     "stop_place": false,
-    "ids": [
-      "3194"
+    "names": [
+      "Pilawa"
     ],
     "bb": [
       [
@@ -23564,8 +23560,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3011"
+    "names": [
+      "Opole Wschodnie"
     ],
     "bb": [
       [
@@ -23603,8 +23599,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4198"
+    "names": [
+      "Sufczyn"
     ],
     "bb": [
       [
@@ -23642,8 +23638,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1603"
+    "names": [
+      "Karłowice"
     ],
     "bb": [
       [
@@ -23681,8 +23677,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "3455"
+    "names": [
+      "Pustelnik"
     ],
     "bb": [
       [
@@ -23711,7 +23707,7 @@
     "uic_ref": null,
     "position": {
       "lat": 52.2786768,
-      "lng": 21.4857840
+      "lng": 21.485784
     }
   },
   {
@@ -23720,8 +23716,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2438"
+    "names": [
+      "Łódź Niciarniana"
     ],
     "bb": [
       [
@@ -23759,8 +23755,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1500"
+    "names": [
+      "Jelcz-Laskowice"
     ],
     "bb": [
       [
@@ -23788,7 +23784,7 @@
     "osm_id": 1508748545,
     "uic_ref": "5102108",
     "position": {
-      "lat": 51.0370220,
+      "lat": 51.037022,
       "lng": 17.3454105
     }
   },
@@ -23798,8 +23794,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "810"
+    "names": [
+      "Dobrzeń Wielki"
     ],
     "bb": [
       [
@@ -23837,8 +23833,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3942"
+    "names": [
+      "Smardzów Wrocławski"
     ],
     "bb": [
       [
@@ -23876,8 +23872,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2370"
+    "names": [
+      "Łaznów"
     ],
     "bb": [
       [
@@ -23905,7 +23901,7 @@
     "osm_id": 2183713958,
     "uic_ref": "5101935",
     "position": {
-      "lat": 51.6311970,
+      "lat": 51.631197,
       "lng": 19.7548526
     }
   },
@@ -23915,8 +23911,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1426"
+    "names": [
+      "Jarosty"
     ],
     "bb": [
       [
@@ -23954,8 +23950,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2341"
+    "names": [
+      "Luciążanka"
     ],
     "bb": [
       [
@@ -23993,8 +23989,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1593"
+    "names": [
+      "Kamieńsk"
     ],
     "bb": [
       [
@@ -24032,8 +24028,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "5012"
+    "names": [
+      "Wolbórka"
     ],
     "bb": [
       [
@@ -24071,8 +24067,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "807"
+    "names": [
+      "Dobryszyce koło Radomska"
     ],
     "bb": [
       [
@@ -24110,8 +24106,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1152"
+    "names": [
+      "Gorzędów"
     ],
     "bb": [
       [
@@ -24149,8 +24145,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "521"
+    "names": [
+      "Chrusty Nowe"
     ],
     "bb": [
       [
@@ -24188,8 +24184,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "4947"
+    "names": [
+      "Wilkoszewice"
     ],
     "bb": [
       [
@@ -24227,8 +24223,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2726"
+    "names": [
+      "Moszczenica"
     ],
     "bb": [
       [
@@ -24266,8 +24262,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2641"
+    "names": [
+      "Milejów"
     ],
     "bb": [
       [
@@ -24305,8 +24301,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "5128"
+    "names": [
+      "Wronki"
     ],
     "bb": [
       [
@@ -24344,8 +24340,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "1385"
+    "names": [
+      "Jackowice"
     ],
     "bb": [
       [
@@ -24383,8 +24379,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "794"
+    "names": [
+      "Dobiegniew"
     ],
     "bb": [
       [
@@ -24422,8 +24418,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "1699"
+    "names": [
+      "Kiekrz"
     ],
     "bb": [
       [
@@ -24469,9 +24465,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4262",
-      "4264"
+    "names": [
+      "Szczecin Dąbie Sda",
+      "Szczecin Dąbie"
     ],
     "bb": [
       [
@@ -24509,8 +24505,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "1878"
+    "names": [
+      "Kostrzyn Wielkopolski"
     ],
     "bb": [
       [
@@ -24548,8 +24544,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3925"
+    "names": [
+      "Słonice"
     ],
     "bb": [
       [
@@ -24587,8 +24583,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "4507"
+    "names": [
+      "Teresin Niepokalanów"
     ],
     "bb": [
       [
@@ -24626,8 +24622,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "2583"
+    "names": [
+      "Miały"
     ],
     "bb": [
       [
@@ -24655,7 +24651,7 @@
     "osm_id": 1278165734,
     "uic_ref": "5102234",
     "position": {
-      "lat": 52.8088420,
+      "lat": 52.808842,
       "lng": 16.1766634
     }
   },
@@ -24665,8 +24661,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "508"
+    "names": [
+      "Choszczno"
     ],
     "bb": [
       [
@@ -24712,8 +24708,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "81"
+    "names": [
+      "Barłogi"
     ],
     "bb": [
       [
@@ -24751,8 +24747,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "4294"
+    "names": [
+      "Szczecin Port Centralny"
     ],
     "bb": [
       [
@@ -24802,8 +24798,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "4269"
+    "names": [
+      "Szczecin Główny"
     ],
     "bb": [
       [
@@ -24841,8 +24837,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "2091"
+    "names": [
+      "Krzewie"
     ],
     "bb": [
       [
@@ -24871,7 +24867,7 @@
     "uic_ref": "5101844",
     "position": {
       "lat": 52.2354639,
-      "lng": 19.1668310
+      "lng": 19.166831
     }
   },
   {
@@ -24880,8 +24876,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "3274"
+    "names": [
+      "Podstolice"
     ],
     "bb": [
       [
@@ -24919,9 +24915,9 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4067",
-      "4072"
+    "names": [
+      "Stargard Rozrz",
+      "Stargard"
     ],
     "bb": [
       [
@@ -24957,8 +24953,8 @@
     "osm_id": 260872674,
     "uic_ref": "5100198",
     "position": {
-      "lat": 53.3395570,
-      "lng": 15.0311260
+      "lat": 53.339557,
+      "lng": 15.031126
     }
   },
   {
@@ -24967,8 +24963,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "3352"
+    "names": [
+      "Poznań Wschód"
     ],
     "bb": [
       [
@@ -24997,7 +24993,7 @@
     "uic_ref": "5102867",
     "position": {
       "lat": 52.4182197,
-      "lng": 16.9714830
+      "lng": 16.971483
     }
   },
   {
@@ -25006,8 +25002,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "840"
+    "names": [
+      "Drawski Młyn"
     ],
     "bb": [
       [
@@ -25035,7 +25031,7 @@
     "osm_id": 11031963802,
     "uic_ref": "5100987",
     "position": {
-      "lat": 52.8608360,
+      "lat": 52.860836,
       "lng": 16.0930584
     }
   },
@@ -25045,8 +25041,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "1831"
+    "names": [
+      "Konin"
     ],
     "bb": [
       [
@@ -25084,8 +25080,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "5133"
+    "names": [
+      "Września"
     ],
     "bb": [
       [
@@ -25123,8 +25119,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "556"
+    "names": [
+      "Cienin"
     ],
     "bb": [
       [
@@ -25152,7 +25148,7 @@
     "osm_id": 29831926,
     "uic_ref": "5100735",
     "position": {
-      "lat": 52.2725450,
+      "lat": 52.272545,
       "lng": 17.9661231
     }
   },
@@ -25162,8 +25158,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2101"
+    "names": [
+      "Krzyż"
     ],
     "bb": [
       [
@@ -25201,8 +25197,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "5707"
+    "names": [
+      "Łódź Zarzew"
     ],
     "bb": [
       [
@@ -25240,8 +25236,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3597"
+    "names": [
+      "Rokietnica"
     ],
     "bb": [
       [
@@ -25279,8 +25275,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "108"
+    "names": [
+      "Bednary"
     ],
     "bb": [
       [
@@ -25309,7 +25305,7 @@
     "uic_ref": "5100594",
     "position": {
       "lat": 52.1055389,
-      "lng": 20.0647850
+      "lng": 20.064785
     }
   },
   {
@@ -25318,8 +25314,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "4047"
+    "names": [
+      "Stara Wieś koło Kutna"
     ],
     "bb": [
       [
@@ -25357,8 +25353,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": true,
-    "ids": [
-      "2699"
+    "names": [
+      "Mokrz"
     ],
     "bb": [
       [
@@ -25396,8 +25392,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "5010"
+    "names": [
+      "Wolanów"
     ],
     "bb": [
       [
@@ -25435,9 +25431,9 @@
     "prefix": "2427_LD",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2427",
-      "2428"
+    "names": [
+      "Łódź Dąbrowa",
+      "Łódź Dąbrowa PBS"
     ],
     "bb": [
       [
@@ -25511,8 +25507,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "815"
+    "names": [
+      "Dolice"
     ],
     "bb": [
       [
@@ -25540,7 +25536,7 @@
     "osm_id": 1278165745,
     "uic_ref": "5100959",
     "position": {
-      "lat": 53.1992040,
+      "lat": 53.199204,
       "lng": 15.2089896
     }
   },
@@ -25550,8 +25546,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "207"
+    "names": [
+      "Bierzwnik"
     ],
     "bb": [
       [
@@ -25580,7 +25576,7 @@
     "uic_ref": "5100673",
     "position": {
       "lat": 53.0240587,
-      "lng": 15.6581210
+      "lng": 15.658121
     }
   },
   {
@@ -25589,8 +25585,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "5428"
+    "names": [
+      "Żychlin"
     ],
     "bb": [
       [
@@ -25628,8 +25624,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": true,
-    "ids": [
-      "3934"
+    "names": [
+      "Słupca"
     ],
     "bb": [
       [
@@ -25667,8 +25663,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "4245"
+    "names": [
+      "Szamotuły"
     ],
     "bb": [
       [
@@ -25706,8 +25702,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "4311"
+    "names": [
+      "Szczecin Zdroje"
     ],
     "bb": [
       [
@@ -25736,7 +25732,7 @@
     "uic_ref": "5103404",
     "position": {
       "lat": 53.3788244,
-      "lng": 14.6369040
+      "lng": 14.636904
     }
   },
   {
@@ -25745,8 +25741,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "4148"
+    "names": [
+      "Strzałkowo"
     ],
     "bb": [
       [
@@ -25784,8 +25780,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "852"
+    "names": [
+      "Drzewica"
     ],
     "bb": [
       [
@@ -25823,8 +25819,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "1757"
+    "names": [
+      "Kłodawa"
     ],
     "bb": [
       [
@@ -25862,8 +25858,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3350"
+    "names": [
+      "Poznań Wola"
     ],
     "bb": [
       [
@@ -25891,7 +25887,7 @@
     "osm_id": 12071864489,
     "uic_ref": "5102835",
     "position": {
-      "lat": 52.4335650,
+      "lat": 52.433565,
       "lng": 16.8503707
     }
   },
@@ -25901,8 +25897,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3962"
+    "names": [
+      "Sochaczew"
     ],
     "bb": [
       [
@@ -25940,8 +25936,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "1816"
+    "names": [
+      "Koło"
     ],
     "bb": [
       [
@@ -25979,8 +25975,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3266"
+    "names": [
+      "Podlesiec"
     ],
     "bb": [
       [
@@ -26018,8 +26014,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3430"
+    "names": [
+      "Przysucha"
     ],
     "bb": [
       [
@@ -26057,8 +26053,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "2036"
+    "names": [
+      "Kramsk"
     ],
     "bb": [
       [
@@ -26096,8 +26092,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "4228"
+    "names": [
+      "Swarzędz"
     ],
     "bb": [
       [
@@ -26135,8 +26131,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3575"
+    "names": [
+      "Reptowo"
     ],
     "bb": [
       [
@@ -26174,8 +26170,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "2454"
+    "names": [
+      "Łódź Pabianicka"
     ],
     "bb": [
       [
@@ -26213,8 +26209,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3157"
+    "names": [
+      "Pęckowo"
     ],
     "bb": [
       [
@@ -26252,8 +26248,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "228"
+    "names": [
+      "Błonie"
     ],
     "bb": [
       [
@@ -26291,8 +26287,8 @@
     "prefix": null,
     "max_speed": 140,
     "stop_place": false,
-    "ids": [
-      "3095"
+    "names": [
+      "Paczkowo"
     ],
     "bb": [
       [
@@ -26330,8 +26326,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1394"
+    "names": [
+      "Jaksice"
     ],
     "bb": [
       [
@@ -26369,8 +26365,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "358"
+    "names": [
+      "Brzoza Bydgoska"
     ],
     "bb": [
       [
@@ -26398,7 +26394,7 @@
     "osm_id": 1205507349,
     "uic_ref": "5100376",
     "position": {
-      "lat": 53.0272810,
+      "lat": 53.027281,
       "lng": 18.0205697
     }
   },
@@ -26408,8 +26404,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4510"
+    "names": [
+      "Terespol Pomorski"
     ],
     "bb": [
       [
@@ -26447,8 +26443,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "5244"
+    "names": [
+      "Zaryń"
     ],
     "bb": [
       [
@@ -26486,8 +26482,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1365"
+    "names": [
+      "Inowrocław Rąbinek"
     ],
     "bb": [
       [
@@ -26525,8 +26521,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1898"
+    "names": [
+      "Kotomierz"
     ],
     "bb": [
       [
@@ -26564,8 +26560,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3261"
+    "names": [
+      "Poddębice"
     ],
     "bb": [
       [
@@ -26603,8 +26599,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3383"
+    "names": [
+      "Pruszcz Pomorski"
     ],
     "bb": [
       [
@@ -26642,8 +26638,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "458"
+    "names": [
+      "Chełmce"
     ],
     "bb": [
       [
@@ -26672,7 +26668,7 @@
     "uic_ref": null,
     "position": {
       "lat": 52.6273616,
-      "lng": 18.4659740
+      "lng": 18.465974
     }
   },
   {
@@ -26681,8 +26677,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4612"
+    "names": [
+      "Twarda Góra"
     ],
     "bb": [
       [
@@ -26720,8 +26716,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3124"
+    "names": [
+      "Parlin"
     ],
     "bb": [
       [
@@ -26759,8 +26755,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "5292"
+    "names": [
+      "Zduńska Wola Karsznice"
     ],
     "bb": [
       [
@@ -26798,8 +26794,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "5348"
+    "names": [
+      "Złotniki Kujawskie"
     ],
     "bb": [
       [
@@ -26837,8 +26833,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3220"
+    "names": [
+      "Piotrków Kujawski"
     ],
     "bb": [
       [
@@ -26876,8 +26872,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2039"
+    "names": [
+      "Kraski"
     ],
     "bb": [
       [
@@ -26915,8 +26911,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4687"
+    "names": [
+      "Warlubie"
     ],
     "bb": [
       [
@@ -26954,8 +26950,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3084"
+    "names": [
+      "Otok"
     ],
     "bb": [
       [
@@ -26993,8 +26989,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4180"
+    "names": [
+      "Subkowy"
     ],
     "bb": [
       [
@@ -27032,8 +27028,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "5295"
+    "names": [
+      "Zduńska Wola Południowa"
     ],
     "bb": [
       [
@@ -27071,8 +27067,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2253"
+    "names": [
+      "Lipie Góry"
     ],
     "bb": [
       [
@@ -27110,8 +27106,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4239"
+    "names": [
+      "Szadek"
     ],
     "bb": [
       [
@@ -27149,8 +27145,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3943"
+    "names": [
+      "Smętowo"
     ],
     "bb": [
       [
@@ -27178,7 +27174,7 @@
     "osm_id": 3658497802,
     "uic_ref": "5103477",
     "position": {
-      "lat": 53.7479590,
+      "lat": 53.747959,
       "lng": 18.6858934
     }
   },
@@ -27188,8 +27184,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3299"
+    "names": [
+      "Ponętów"
     ],
     "bb": [
       [
@@ -27218,7 +27214,7 @@
     "uic_ref": "5102929",
     "position": {
       "lat": 52.1970161,
-      "lng": 18.8108910
+      "lng": 18.810891
     }
   },
   {
@@ -27227,8 +27223,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1770"
+    "names": [
+      "Kłudna"
     ],
     "bb": [
       [
@@ -27266,8 +27262,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "52"
+    "names": [
+      "Babiak"
     ],
     "bb": [
       [
@@ -27295,7 +27291,7 @@
     "osm_id": 4712859499,
     "uic_ref": "5100351",
     "position": {
-      "lat": 52.3535350,
+      "lat": 52.353535,
       "lng": 18.6701836
     }
   },
@@ -27305,10 +27301,10 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "5212",
-      "5213",
-      "5214"
+    "names": [
+      "Zajączkowo Tcz. Ztb",
+      "Zajączkowo Tczewskie PZS R700",
+      "Zajączkowo Tcz. Ztc"
     ],
     "bb": [
       [
@@ -27344,7 +27340,7 @@
     "osm_id": 9215829078,
     "uic_ref": null,
     "position": {
-      "lat": 54.1239660,
+      "lat": 54.123966,
       "lng": 18.7622724
     }
   },
@@ -27354,8 +27350,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "711"
+    "names": [
+      "Dąbie nad Nerem"
     ],
     "bb": [
       [
@@ -27393,8 +27389,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "4560"
+    "names": [
+      "Trzciniec"
     ],
     "bb": [
       [
@@ -27440,8 +27436,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2173"
+    "names": [
+      "Laskowice Pomorskie"
     ],
     "bb": [
       [
@@ -27479,8 +27475,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2871"
+    "names": [
+      "Nowa Wieś Wielka"
     ],
     "bb": [
       [
@@ -27518,8 +27514,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2503"
+    "names": [
+      "Maksymilianowo"
     ],
     "bb": [
       [
@@ -27557,8 +27553,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "1601"
+    "names": [
+      "Karczyn"
     ],
     "bb": [
       [
@@ -27596,9 +27592,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "968",
-      "970"
+    "names": [
+      "Gdańsk Olszynka R1 PZS",
+      "Gdańsk Olszynka"
     ],
     "bb": [
       [
@@ -27636,8 +27632,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "3148"
+    "names": [
+      "Pelplin"
     ],
     "bb": [
       [
@@ -27666,7 +27662,7 @@
     "uic_ref": "5102724",
     "position": {
       "lat": 53.9269222,
-      "lng": 18.7072770
+      "lng": 18.707277
     }
   },
   {
@@ -27675,8 +27671,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "2711"
+    "names": [
+      "Morzeszczyn"
     ],
     "bb": [
       [
@@ -27704,7 +27700,7 @@
     "osm_id": 3658655223,
     "uic_ref": "5102384",
     "position": {
-      "lat": 53.8367340,
+      "lat": 53.836734,
       "lng": 18.6862241
     }
   },
@@ -27714,9 +27710,9 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": false,
-    "ids": [
-      "984",
-      "985"
+    "names": [
+      "Gdańsk Port Północny",
+      "Gdańsk Port Północny R4 PZS"
     ],
     "bb": [
       [
@@ -27778,8 +27774,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "5543"
+    "names": [
+      "Łódź Retkinia"
     ],
     "bb": [
       [
@@ -27808,7 +27804,7 @@
     "uic_ref": "5104718",
     "position": {
       "lat": 51.7403478,
-      "lng": 19.4065800
+      "lng": 19.40658
     }
   },
   {
@@ -27817,8 +27813,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1092"
+    "names": [
+      "Głowno"
     ],
     "bb": [
       [
@@ -27856,8 +27852,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "4143"
+    "names": [
+      "Stryków"
     ],
     "bb": [
       [
@@ -27895,8 +27891,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3828"
+    "names": [
+      "Sieradz Męka"
     ],
     "bb": [
       [
@@ -27934,8 +27930,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "1263"
+    "names": [
+      "Grudze"
     ],
     "bb": [
       [
@@ -27973,8 +27969,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "939"
+    "names": [
+      "Gawrony"
     ],
     "bb": [
       [
@@ -28012,8 +28008,8 @@
     "prefix": "2437_LM",
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "2437"
+    "names": [
+      "Łódź Marysin"
     ],
     "bb": [
       [
@@ -28051,8 +28047,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3829"
+    "names": [
+      "Sieradz Warta"
     ],
     "bb": [
       [
@@ -28090,8 +28086,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "3835"
+    "names": [
+      "Sierpów"
     ],
     "bb": [
       [
@@ -28129,8 +28125,8 @@
     "prefix": "5313_ZK",
     "max_speed": 70,
     "stop_place": false,
-    "ids": [
-      "5313"
+    "names": [
+      "Zgierz Kontrewers"
     ],
     "bb": [
       [
@@ -28159,7 +28155,7 @@
     "uic_ref": "5101392",
     "position": {
       "lat": 51.8648041,
-      "lng": 19.3403210
+      "lng": 19.340321
     }
   },
   {
@@ -28168,8 +28164,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "5548"
+    "names": [
+      "Łódź Radogoszcz Wschód"
     ],
     "bb": [
       [
@@ -28207,8 +28203,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "5712"
+    "names": [
+      "Jedlicze koło Zgierza"
     ],
     "bb": [
       [
@@ -28246,8 +28242,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "2580"
+    "names": [
+      "Męcka Wola"
     ],
     "bb": [
       [
@@ -28285,8 +28281,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": false,
-    "ids": [
-      "3501"
+    "names": [
+      "Radom Krychnowice"
     ],
     "bb": [
       [
@@ -28324,8 +28320,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "2424"
+    "names": [
+      "Łódź Arturówek"
     ],
     "bb": [
       [
@@ -28363,8 +28359,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "450"
+    "names": [
+      "Chechło"
     ],
     "bb": [
       [
@@ -28402,8 +28398,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "5547"
+    "names": [
+      "Łódź Warszawska"
     ],
     "bb": [
       [
@@ -28432,7 +28428,7 @@
     "uic_ref": "5104715",
     "position": {
       "lat": 51.8080021,
-      "lng": 19.4712300
+      "lng": 19.47123
     }
   },
   {
@@ -28441,8 +28437,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "1261"
+    "names": [
+      "Grotniki"
     ],
     "bb": [
       [
@@ -28480,8 +28476,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "5710"
+    "names": [
+      "Głowno Północne"
     ],
     "bb": [
       [
@@ -28519,8 +28515,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "1588"
+    "names": [
+      "Kamień Łowicki"
     ],
     "bb": [
       [
@@ -28549,7 +28545,7 @@
     "uic_ref": "5101678",
     "position": {
       "lat": 51.9887032,
-      "lng": 19.7531510
+      "lng": 19.753151
     }
   },
   {
@@ -28558,8 +28554,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "3940"
+    "names": [
+      "Smardzew"
     ],
     "bb": [
       [
@@ -28597,8 +28593,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "5704"
+    "names": [
+      "Pabianice Północne"
     ],
     "bb": [
       [
@@ -28636,8 +28632,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "3850"
+    "names": [
+      "Skalmierz"
     ],
     "bb": [
       [
@@ -28675,8 +28671,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "5312"
+    "names": [
+      "Zgierz Jaracza"
     ],
     "bb": [
       [
@@ -28714,8 +28710,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "313"
+    "names": [
+      "Bratoszewice"
     ],
     "bb": [
       [
@@ -28743,7 +28739,7 @@
     "osm_id": 60120651,
     "uic_ref": "5100593",
     "position": {
-      "lat": 51.9385090,
+      "lat": 51.938509,
       "lng": 19.6527947
     }
   },
@@ -28753,8 +28749,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "2455"
+    "names": [
+      "Łódź Radogoszcz Zachód"
     ],
     "bb": [
       [
@@ -28792,8 +28788,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "4231"
+    "names": [
+      "Swędów"
     ],
     "bb": [
       [
@@ -28831,8 +28827,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "824"
+    "names": [
+      "Domaniewice"
     ],
     "bb": [
       [
@@ -28860,7 +28856,7 @@
     "osm_id": 3459181765,
     "uic_ref": "5100971",
     "position": {
-      "lat": 52.0205700,
+      "lat": 52.02057,
       "lng": 19.8210551
     }
   },
@@ -28870,8 +28866,8 @@
     "prefix": null,
     "max_speed": 110,
     "stop_place": true,
-    "ids": [
-      "1802"
+    "names": [
+      "Kolumna"
     ],
     "bb": [
       [
@@ -28909,8 +28905,8 @@
     "prefix": "1057_Gl",
     "max_speed": 100,
     "stop_place": false,
-    "ids": [
-      "1057"
+    "names": [
+      "Glinnik"
     ],
     "bb": [
       [
@@ -28948,8 +28944,8 @@
     "prefix": null,
     "max_speed": 90,
     "stop_place": false,
-    "ids": [
-      "2418"
+    "names": [
+      "Łowicz Przedmieście"
     ],
     "bb": [
       [
@@ -28997,7 +28993,7 @@
     "osm_id": 2517728067,
     "uic_ref": "5102077",
     "position": {
-      "lat": 52.0930530,
+      "lat": 52.093053,
       "lng": 19.9466922
     }
   },
@@ -29007,8 +29003,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "825"
+    "names": [
+      "Domaniewice Centrum"
     ],
     "bb": [
       [
@@ -29046,8 +29042,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "1571"
+    "names": [
+      "Kalisz Winiary"
     ],
     "bb": [
       [
@@ -29085,8 +29081,8 @@
     "prefix": null,
     "max_speed": 70,
     "stop_place": true,
-    "ids": [
-      "3090"
+    "names": [
+      "Ozorków Nowe Miasto"
     ],
     "bb": [
       [
@@ -29124,8 +29120,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "2456"
+    "names": [
+      "Łódź Stoki"
     ],
     "bb": [
       [
@@ -29163,8 +29159,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "5711"
+    "names": [
+      "Zgierz Rudunki"
     ],
     "bb": [
       [
@@ -29202,8 +29198,8 @@
     "prefix": null,
     "max_speed": 120,
     "stop_place": true,
-    "ids": [
-      "5709"
+    "names": [
+      "Izabelów"
     ],
     "bb": [
       [
@@ -29241,8 +29237,8 @@
     "prefix": null,
     "max_speed": 100,
     "stop_place": true,
-    "ids": [
-      "1059"
+    "names": [
+      "Glinnik Wieś"
     ],
     "bb": [
       [
@@ -29280,9 +29276,9 @@
     "prefix": "3577_Rt",
     "max_speed": 60,
     "stop_place": false,
-    "ids": [
-      "3577",
-      "3578"
+    "names": [
+      "Retkinia R.2",
+      "Retkinia"
     ],
     "bb": [
       [
@@ -29320,10 +29316,10 @@
     "prefix": "919_Ga",
     "max_speed": 110,
     "stop_place": false,
-    "ids": [
-      "919",
-      "920",
-      "921"
+    "names": [
+      "Gajewniki",
+      "Gajewniki Roz.3",
+      "Gajewniki Roz.7"
     ],
     "bb": [
       [
@@ -29361,8 +29357,8 @@
     "prefix": null,
     "max_speed": 60,
     "stop_place": true,
-    "ids": [
-      "2423"
+    "names": [
+      "Łódź Andrzejów Szosa"
     ],
     "bb": [
       [
@@ -29400,8 +29396,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "2453"
+    "names": [
+      "Łódź Olechów Zachód"
     ],
     "bb": [
       [
@@ -29439,8 +29435,8 @@
     "prefix": null,
     "max_speed": 80,
     "stop_place": true,
-    "ids": [
-      "2451"
+    "names": [
+      "Łódź Olechów Wiadukt"
     ],
     "bb": [
       [

--- a/common/src/main/java/tools/simrail/backend/common/border/MapBorderPoint.java
+++ b/common/src/main/java/tools/simrail/backend/common/border/MapBorderPoint.java
@@ -45,10 +45,10 @@ public final class MapBorderPoint {
   @JsonProperty("name")
   private String name;
   /**
-   * The external (SimRail) point ids.
+   * The alternative names of the point.
    */
-  @JsonProperty("ext_point_ids")
-  private Set<String> simRailPointIds;
+  @JsonProperty("point_names")
+  private Set<String> pointNames;
   /**
    * The points that must follow the current point to be in the border. Can be null if none are required.
    */

--- a/common/src/main/java/tools/simrail/backend/common/border/MapBorderPointProvider.java
+++ b/common/src/main/java/tools/simrail/backend/common/border/MapBorderPointProvider.java
@@ -43,7 +43,7 @@ import tools.jackson.databind.ObjectMapper;
 public final class MapBorderPointProvider {
 
   // visible for testing only
-  final Map<String, MapBorderPoint> mapBorderPointIds;
+  final Map<String, MapBorderPoint> borderPointsByName;
 
   @Autowired
   public MapBorderPointProvider(
@@ -55,30 +55,30 @@ public final class MapBorderPointProvider {
     try (var inputStream = borderPointsResource.getInputStream()) {
       List<MapBorderPoint> points = objectMapper.readValue(inputStream, borderPointsType);
 
-      this.mapBorderPointIds = new HashMap<>();
+      this.borderPointsByName = new HashMap<>();
       for (var point : points) {
-        point.getSimRailPointIds().forEach(id -> this.mapBorderPointIds.put(id, point));
+        point.getPointNames().forEach(name -> this.borderPointsByName.put(name, point));
       }
     }
   }
 
   /**
-   * Get if the given point id is at the border of the playable SimRail map.
+   * Get if the given point is at the border of the playable SimRail map.
    *
-   * @param simRailPointId the id of the point to check.
-   * @return true if the given point id is at the border of the playable SimRail map, false otherwise.
+   * @param pointName the name of the point to check.
+   * @return true if the given point is at the border of the playable SimRail map, false otherwise.
    */
-  public boolean isMapBorderPoint(@NonNull String simRailPointId) {
-    return this.mapBorderPointIds.containsKey(simRailPointId);
+  public boolean isMapBorderPoint(@NonNull String pointName) {
+    return this.borderPointsByName.containsKey(pointName);
   }
 
   /**
-   * Finds a border point mapping for the given point id.
+   * Finds a border point mapping for the given point name.
    *
-   * @param simRailPointId the id of the point to get the border point mapping of.
-   * @return an optional holding the map border point for the given point id if one exists.
+   * @param pointName the name of the point to get the border point mapping of.
+   * @return an optional holding the map border point for the given point name if one exists.
    */
-  public @NonNull Optional<MapBorderPoint> findMapBorderPoint(@NonNull String simRailPointId) {
-    return Optional.ofNullable(this.mapBorderPointIds.get(simRailPointId));
+  public @NonNull Optional<MapBorderPoint> findMapBorderPoint(@NonNull String pointName) {
+    return Optional.ofNullable(this.borderPointsByName.get(pointName));
   }
 }

--- a/common/src/main/java/tools/simrail/backend/common/point/SimRailPoint.java
+++ b/common/src/main/java/tools/simrail/backend/common/point/SimRailPoint.java
@@ -55,11 +55,11 @@ public final class SimRailPoint {
   @JsonProperty("id")
   private UUID id;
   /**
-   * The SimRail point ids that are associated with this point.
+   * The names of points that all map to this point. Contains at least one element.
    */
   @NonNull
-  @JsonProperty("ids")
-  private Set<String> simRailPointIds;
+  @JsonProperty("names")
+  private Set<String> pointNames;
 
   /**
    * The prefix of the point, used for example as a prefix for signal names. Null if the prefix is unknown.

--- a/common/src/main/java/tools/simrail/backend/common/point/SimRailPointProvider.java
+++ b/common/src/main/java/tools/simrail/backend/common/point/SimRailPointProvider.java
@@ -73,23 +73,13 @@ public final class SimRailPointProvider {
   }
 
   /**
-   * Finds a single point based on the given SimRail point id.
-   *
-   * @param pointId the SimRail point id of the point to get.
-   * @return an optional holding the point if one with the given SimRail point id exists.
-   */
-  public @NonNull Optional<SimRailPoint> findPointByPointId(@NonNull String pointId) {
-    return this.points.stream().filter(point -> point.getSimRailPointIds().contains(pointId)).findFirst();
-  }
-
-  /**
    * Finds a single point based on the given point name.
    *
    * @param name the name of the point to get.
    * @return an optional holding the point if one with the given name exists.
    */
   public @NonNull Optional<SimRailPoint> findPointByName(@NonNull String name) {
-    return this.points.stream().filter(point -> point.getName().equals(name)).findFirst();
+    return this.points.stream().filter(point -> point.getPointNames().contains(name)).findFirst();
   }
 
   /**

--- a/common/src/test/java/tools/simrail/backend/common/border/MapBorderPointProviderTest.java
+++ b/common/src/test/java/tools/simrail/backend/common/border/MapBorderPointProviderTest.java
@@ -53,22 +53,22 @@ public final class MapBorderPointProviderTest {
 
   @Test
   void testAllBorderPointsWereLoaded() {
-    var borderPoints = this.borderPointProvider.mapBorderPointIds;
+    var borderPoints = this.borderPointProvider.borderPointsByName;
     Assertions.assertEquals(52, borderPoints.size());
   }
 
   @Test
   void testBorderPointIdsAreUnique() throws IOException {
     var jsonMapper = new JsonMapper();
-    var seenPointIds = new HashSet<String>();
+    var seenPointNames = new HashSet<String>();
     try (var stream = this.borderPointsResource.getInputStream()) {
       var borderPoints = jsonMapper.readTree(stream);
       for (var borderPoint : borderPoints) {
-        var pointIds = borderPoint.get("ext_point_ids");
-        for (var pointIdNode : pointIds) {
-          var pointId = pointIdNode.asString();
-          if (!seenPointIds.add(pointId)) {
-            Assertions.fail("Duplicate border point id: " + pointId);
+        var pointNames = borderPoint.get("point_names");
+        for (var pointNameNode : pointNames) {
+          var pointName = pointNameNode.asString();
+          if (!seenPointNames.add(pointName)) {
+            Assertions.fail("Duplicate border point name: " + pointName);
           }
         }
       }
@@ -77,11 +77,11 @@ public final class MapBorderPointProviderTest {
 
   @Test
   void testAllBorderPointsAreMappedUniquely() {
-    var borderPoints = this.borderPointProvider.mapBorderPointIds.keySet();
+    var borderPoints = this.borderPointProvider.borderPointsByName.keySet();
     for (var borderPoint : borderPoints) {
-      this.pointProvider.findPointByPointId(borderPoint).ifPresent(point -> {
-        for (String pointId : point.getSimRailPointIds()) {
-          Assertions.assertTrue(this.borderPointProvider.isMapBorderPoint(pointId), pointId);
+      this.pointProvider.findPointByName(borderPoint).ifPresent(point -> {
+        for (String pointName : point.getPointNames()) {
+          Assertions.assertTrue(this.borderPointProvider.isMapBorderPoint(pointName), pointName);
         }
       });
     }
@@ -101,8 +101,8 @@ public final class MapBorderPointProviderTest {
       MapBorderPoint end = null;
       for (var index = 0; index < timetable.size(); index++) {
         var timetableEntry = timetable.get(index);
-        var pointId = timetableEntry.get("pointId").asString();
-        var borderPoint = this.borderPointProvider.findMapBorderPoint(pointId).orElse(null);
+        var pointName = timetableEntry.get("nameOfPoint").asString();
+        var borderPoint = this.borderPointProvider.findMapBorderPoint(pointName).orElse(null);
         if (borderPoint == null) {
           continue;
         }
@@ -112,7 +112,7 @@ public final class MapBorderPointProviderTest {
           var requiredNext = borderPoint.getRequiredNextPoints();
           if (requiredNext != null) {
             var nextEntry = timetable.get(index + 1);
-            if (nextEntry == null || !requiredNext.contains(nextEntry.get("pointId").asString())) {
+            if (nextEntry == null || !requiredNext.contains(nextEntry.get("nameOfPoint").asString())) {
               continue;
             }
           }

--- a/common/src/test/java/tools/simrail/backend/common/point/SimRailPointProviderTest.java
+++ b/common/src/test/java/tools/simrail/backend/common/point/SimRailPointProviderTest.java
@@ -135,14 +135,14 @@ public final class SimRailPointProviderTest {
   }
 
   @Test
-  void testAllSimRailPointIdsAreOnlyAssociatedOnce() {
+  void testAllPointNamesAreOnlyAssociatedOnce() {
     var points = this.pointProvider.points;
-    var seenPointIds = new HashSet<String>();
+    var seenPointNames = new HashSet<String>();
     for (var point : points) {
-      var simRailPointIds = point.getSimRailPointIds();
-      for (var simRailPointId : simRailPointIds) {
-        if (!seenPointIds.add(simRailPointId)) {
-          Assertions.fail("Detected duplicate SimRail point id mapping: " + simRailPointId);
+      var pointNames = point.getPointNames();
+      for (var pointName : pointNames) {
+        if (!seenPointNames.add(pointName)) {
+          Assertions.fail("Detected duplicate SimRail point name mapping: " + pointName);
         }
       }
     }
@@ -174,15 +174,15 @@ public final class SimRailPointProviderTest {
   }
 
   @Test
-  void testFindPointBySimRailPointId() {
-    var point = this.pointProvider.findPointByPointId("5262");
+  void testFindPointByName() {
+    var point = this.pointProvider.findPointByName("Warszawa Wschodnia");
     Assertions.assertTrue(point.isPresent());
-    Assertions.assertEquals("Zawiercie", point.get().getName());
+    Assertions.assertEquals("Warszawa Wschodnia", point.get().getName());
   }
 
   @Test
-  void testFindPointByName() {
-    var point = this.pointProvider.findPointByName("Warszawa Wschodnia");
+  void testFindPointByAlternativeName() {
+    var point = this.pointProvider.findPointByName("Warszawa Wsch. R.58");
     Assertions.assertTrue(point.isPresent());
     Assertions.assertEquals("Warszawa Wschodnia", point.get().getName());
   }
@@ -201,9 +201,8 @@ public final class SimRailPointProviderTest {
     for (var trainRun : trainRuns) {
       var timetable = (ArrayNode) trainRun.get("timetable");
       for (var timetableEntry : timetable) {
-        var pointId = timetableEntry.get("pointId").asString();
         var pointName = timetableEntry.get("nameOfPoint").asString();
-        var point = this.pointProvider.findPointByPointId(pointId);
+        var point = this.pointProvider.findPointByName(pointName);
         if (point.isEmpty()) {
           missingPoints.add(pointName);
         }
@@ -226,10 +225,10 @@ public final class SimRailPointProviderTest {
     for (var trainRun : trainRuns) {
       var timetable = trainRun.get("timetable");
       for (var timetableEntry : timetable) {
-        var pointId = timetableEntry.get("pointId").asString();
         var maxSpeed = timetableEntry.get("maxSpeed").asInt();
+        var pointName = timetableEntry.get("nameOfPoint").asString();
         this.pointProvider
-          .findPointByPointId(pointId)
+          .findPointByName(pointName)
           .ifPresent(point -> speedLimitsPerPoint.merge(point.getId(), maxSpeed, Math::max));
       }
     }

--- a/common/src/test/java/tools/simrail/backend/common/signal/PlatformSignalProviderTest.java
+++ b/common/src/test/java/tools/simrail/backend/common/signal/PlatformSignalProviderTest.java
@@ -144,9 +144,8 @@ public class PlatformSignalProviderTest {
           && !missingPoints.contains(pointName)
           && !pointsWithWrongPlatformMapping.contains(pointName)) {
           // get the point associated with the stop
-          var pointId = timetableEntry.get("pointId").asString();
-          var point = this.pointProvider.findPointByPointId(pointId);
-          Assertions.assertTrue(point.isPresent(), "Missing point " + pointId);
+          var point = this.pointProvider.findPointByName(pointName);
+          Assertions.assertTrue(point.isPresent(), "Missing point " + pointName);
 
           // get the track information of the stop and the signal info for the point
           var track = timetableEntry.get("track").asInt();

--- a/info-collector/src/main/java/tools/simrail/backend/collector/journey/SimRailServerTimetableCollector.java
+++ b/info-collector/src/main/java/tools/simrail/backend/collector/journey/SimRailServerTimetableCollector.java
@@ -150,7 +150,7 @@ class SimRailServerTimetableCollector {
       // update the current status if the journey is within the playable border
       var timetableEntry = timetable.get(index);
       var wasInBorder = inBorder; // keeps track if the journey was in border before the border check
-      var borderPoint = this.borderPointProvider.findMapBorderPoint(timetableEntry.getPointId()).orElse(null);
+      var borderPoint = this.borderPointProvider.findMapBorderPoint(timetableEntry.getPointName()).orElse(null);
       if (borderPoint != null && !inBorder) {
         // if we are currently not within the map border we need to check if the journey moved into the
         // map border before recording the events as they should be marked as in-border at the map border
@@ -163,7 +163,7 @@ class SimRailServerTimetableCollector {
         if (requiredNextPoints != null) {
           if (index != lastTimetableIndex) {
             var next = timetable.get(index + 1);
-            if (requiredNextPoints.contains(next.getPointId())) {
+            if (requiredNextPoints.contains(next.getPointName())) {
               inBorder = true;
             }
           }
@@ -174,7 +174,7 @@ class SimRailServerTimetableCollector {
 
       // get the point associated with the event, if the point is not registered
       // we deem it irrelevant and don't want an event for the point
-      var eventPoint = this.pointProvider.findPointByPointId(timetableEntry.getPointId()).orElse(null);
+      var eventPoint = this.pointProvider.findPointByName(timetableEntry.getPointName()).orElse(null);
       if (eventPoint == null) {
         if (borderPoint != null && wasInBorder) {
           // if the current event was at a border point, and we were in border before the check
@@ -335,7 +335,7 @@ class SimRailServerTimetableCollector {
     @NonNull SimRailAwsTimetableEntry timetableEntry
   ) {
     // get the point where the event is happening, return if the point is not registered
-    var point = this.pointProvider.findPointByPointId(timetableEntry.getPointId()).orElse(null);
+    var point = this.pointProvider.findPointByName(timetableEntry.getPointName()).orElse(null);
     if (point == null) {
       return null;
     }
@@ -435,7 +435,7 @@ class SimRailServerTimetableCollector {
       // check if the point of the event is known if not just add it as fixed
       // as the event will be sorted out later anyway
       var entry = timetable.get(index);
-      var point = this.pointProvider.findPointByPointId(entry.getPointId()).orElse(null);
+      var point = this.pointProvider.findPointByName(entry.getPointName()).orElse(null);
       if (point == null) {
         currentEvent = entry;
         fixedEvents.add(entry);
@@ -444,7 +444,7 @@ class SimRailServerTimetableCollector {
 
       // check if the point of the current event and the checking event are the same in our mapping
       // if that is not the case just continue as there is nothing to merge
-      if (!point.getSimRailPointIds().contains(currentEvent.getPointId())) {
+      if (!point.getPointNames().contains(currentEvent.getPointName())) {
         if (seenPointIds.add(point.getId())) {
           currentEvent = entry;
           fixedEvents.add(entry);

--- a/rest-api/src/main/java/tools/simrail/backend/api/point/SimRailPointService.java
+++ b/rest-api/src/main/java/tools/simrail/backend/api/point/SimRailPointService.java
@@ -99,20 +99,6 @@ class SimRailPointService {
   }
 
   /**
-   * Finds the point with the given SimRail id, either by looking it up or from cache.
-   *
-   * @param id the SimRail id of the point to get.
-   * @return an optional holding the point with the given id, if one exists.
-   */
-  @Cacheable(cacheNames = "point_cache", key = "'by_point_id' + #id")
-  public @NonNull Optional<PointInfoDto> findPointByPointId(@NonNull String id) {
-    return this.pointProvider.findPointByPointId(id).map(point -> {
-      var platformSignals = this.platformSignalProvider.findSignalsByPoint(point.getId());
-      return this.pointInfoConverter.apply(point, platformSignals);
-    });
-  }
-
-  /**
    * Lists all points that are registered according to the given filter and paging parameters.
    *
    * @param countries the countries in which the points to return may be located.

--- a/rest-api/src/main/java/tools/simrail/backend/api/point/SimRailPointV1Controller.java
+++ b/rest-api/src/main/java/tools/simrail/backend/api/point/SimRailPointV1Controller.java
@@ -169,45 +169,6 @@ class SimRailPointV1Controller {
   }
 
   /**
-   * Get a point by its SimRail point id.
-   */
-  @GetMapping("/by-point-id/{id}")
-  @Operation(
-    summary = "Get a point by its SimRail point id",
-    description = """
-      Gets a point by its SimRail point id". Note that the resulting points are grouped by their operational unit, for
-      example '2528' (Małogoszcz) and '5460' (Małogoszcz PZS R35) will both return 'Małogoszcz'. Also note that some
-      points might not return any result if they are too close together and one point represents them enough
-      (for example the case for 'Zawiercie' and 'Zawiercie GT')
-      """,
-    parameters = {
-      @Parameter(name = "id", description = "The id of the point in the SimRail backend, e.g. 2371")
-    },
-    responses = {
-      @ApiResponse(
-        responseCode = "200",
-        description = "The point with the given id was successfully resolved"),
-      @ApiResponse(
-        responseCode = "400",
-        description = "One of the filter parameters is invalid",
-        content = @Content(schema = @Schema(hidden = true))),
-      @ApiResponse(
-        responseCode = "404",
-        description = "No point can be found with the given id",
-        content = @Content(schema = @Schema(hidden = true))),
-      @ApiResponse(
-        responseCode = "500",
-        description = "An internal error occurred while processing the request",
-        content = @Content(schema = @Schema(hidden = true))),
-    }
-  )
-  public @NonNull Optional<PointInfoDto> findPointBySimRailPointId(
-    @PathVariable("id") @Pattern(regexp = "[0-9]{2,4}") String pointId
-  ) {
-    return this.pointService.findPointByPointId(pointId);
-  }
-
-  /**
    * Finds points whose name are matching the given search query.
    */
   @GetMapping("/by-name/{searchQuery}")


### PR DESCRIPTION
Timetables are currently being updated, which also includes that point ids no longer identify a point. Some placeholder points now use random ids. To circumvent that, we need to identify points by their name instead of the point id.